### PR TITLE
Add missing comma in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "▴ Open source, self hosted, developer oriented translation tool",
   "keywords": [
     "elixir",
-    "ember.js"
+    "ember.js",
     "i18n",
     "translations"
   ],


### PR DESCRIPTION
## What was the issue?
No issue was open for this — I'm going straight for a PR. The issue was that the `app.json` file was invalid because of a missing comma in the `keywords` section, which also broke the "Deploy to Heroku" button.

## What are you trying to achieve?
Add the missing comma to _Make `app.json` Valid Again_, which in turn fixes the "Deploy to Heroku" feature.