### PR TITLE
Migrate the database in app.json before seeding it

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
   "logo": "https://raw.githubusercontent.com/mirego/accent/master/logo.svg",
   "success_url": "/",
   "scripts": {
-    "postdeploy": "mix run ./priv/repo/seeds.exs"
+    "postdeploy": "mix do ecto.migrate, run ./priv/repo/seeds.exs"
   },
   "addons": [
     {


### PR DESCRIPTION
When the app is first deployed, it has a `DATABASE_URL` but no structure. We need to migrate it before seeding it.