### PR TITLE
Use Ecto embedded schema to store previous translation on operation

### DIFF
--- a/lib/accent/schemas/operation.ex
+++ b/lib/accent/schemas/operation.ex
@@ -32,9 +32,10 @@ defmodule Accent.Operation do
 
     field(:value_type, :string)
 
-    field(:previous_translation, :map)
     field(:rollbacked, :boolean, default: false)
     field(:stats, {:array, :map}, default: [])
+
+    embeds_one(:previous_translation, Accent.PreviousTranslation)
 
     belongs_to(:document, Accent.Document)
     belongs_to(:revision, Accent.Revision)

--- a/lib/accent/schemas/previous_translation.ex
+++ b/lib/accent/schemas/previous_translation.ex
@@ -1,38 +1,39 @@
 defmodule Accent.PreviousTranslation do
+  use Ecto.Schema
+
+  @fields ~w(
+    proposed_text
+    corrected_text
+    conflicted_text
+    conflicted
+    removed
+    value_type
+  )a
+
+  @primary_key false
+  embedded_schema do
+    field(:proposed_text, :string, default: "")
+    field(:corrected_text, :string, default: "")
+    field(:conflicted_text, :string, default: "")
+    field(:conflicted, :boolean, default: false)
+    field(:removed, :boolean, default: false)
+    field(:value_type, :string)
+  end
+
   @doc """
     ## Examples
 
     iex> Accent.PreviousTranslation.from_translation(nil)
-    %{}
+    %Accent.PreviousTranslation{}
     iex> Accent.PreviousTranslation.from_translation(%{})
-    %{}
+    %Accent.PreviousTranslation{}
     iex> Accent.PreviousTranslation.from_translation(%Accent.Translation{proposed_text: "a", corrected_text: "b", conflicted_text: "c", conflicted: true, removed: false, value_type: "text"})
-    %{"proposed_text" => "a", "corrected_text" => "b", "conflicted_text" => "c", "conflicted" => true, "removed" => false, "value_type" => "text"}
-    iex> Accent.PreviousTranslation.to_translation(%{"proposed_text" => "a", "corrected_text" => "b", "conflicted_text" => "c", "conflicted" => true, "removed" => false, "value_type" => "text"})
-    %{proposed_text: "a", corrected_text: "b", conflicted_text: "c", conflicted: true, removed: false, value_type: "text"}
+    %Accent.PreviousTranslation{proposed_text: "a", corrected_text: "b", conflicted_text: "c", conflicted: true, removed: false, value_type: "text"}
   """
-  def from_translation(nil), do: %{}
-  def from_translation(translation) when map_size(translation) == 0, do: %{}
+  def from_translation(nil), do: from_translation(%{})
 
   def from_translation(translation) do
-    %{
-      "proposed_text" => translation.proposed_text,
-      "corrected_text" => translation.corrected_text,
-      "conflicted_text" => translation.conflicted_text,
-      "conflicted" => translation.conflicted,
-      "removed" => translation.removed,
-      "value_type" => translation.value_type
-    }
-  end
-
-  def to_translation(translation) do
-    %{
-      proposed_text: translation["proposed_text"],
-      corrected_text: translation["corrected_text"],
-      conflicted_text: translation["conflicted_text"],
-      conflicted: translation["conflicted"],
-      removed: translation["removed"],
-      value_type: translation["value_type"]
-    }
+    fields = Map.take(translation, @fields)
+    struct(__MODULE__, fields)
   end
 end

--- a/lib/graphql/types/activity.ex
+++ b/lib/graphql/types/activity.ex
@@ -22,17 +22,16 @@ defmodule Accent.GraphQL.Types.Activity do
       end)
     end
 
-    field(:is_removed, :boolean, resolve: field_alias("removed"))
-    field(:is_conflicted, :boolean, resolve: field_alias("conflicted"))
-    field(:proposed_text, :string, resolve: field_alias("proposed_text"))
+    field(:is_removed, :boolean, resolve: field_alias(:removed))
+    field(:is_conflicted, :boolean, resolve: field_alias(:conflicted))
+    field(:proposed_text, :string)
+    field(:conflicted_text, :string)
 
     field :text, :string do
       resolve(fn previous_translation, _, _ ->
-        {:ok, previous_translation["corrected_text"] || previous_translation["proposed_text"]}
+        {:ok, previous_translation.corrected_text || previous_translation.proposed_text}
       end)
     end
-
-    field(:conflicted_text, :string, resolve: field_alias("conflicted_text"))
   end
 
   object :activity do

--- a/lib/movement/mappers/operation.ex
+++ b/lib/movement/mappers/operation.ex
@@ -1,4 +1,6 @@
 defmodule Movement.Mappers.Operation do
+  alias Accent.PreviousTranslation
+
   @spec map(binary, map, map) :: Movement.Operation.t()
   def map(action = "new", current_translation, suggested_translation) do
     %Movement.Operation{
@@ -11,7 +13,7 @@ defmodule Movement.Mappers.Operation do
       revision_id: Map.get(suggested_translation, :revision_id),
       document_id: Map.get(suggested_translation, :document_id),
       version_id: Map.get(suggested_translation, :version_id),
-      previous_translation: from_translation(current_translation)
+      previous_translation: PreviousTranslation.from_translation(current_translation)
     }
   end
 
@@ -27,21 +29,7 @@ defmodule Movement.Mappers.Operation do
       version_id: Map.get(suggested_translation, :version_id, current_translation.version_id),
       value_type: Map.get(suggested_translation, :value_type, current_translation.value_type),
       translation_id: Map.get(current_translation, :id),
-      previous_translation: from_translation(current_translation)
-    }
-  end
-
-  defp from_translation(nil), do: %{}
-  defp from_translation(translation) when map_size(translation) == 0, do: %{}
-
-  defp from_translation(translation) do
-    %{
-      "proposed_text" => translation.proposed_text,
-      "corrected_text" => translation.corrected_text,
-      "conflicted_text" => translation.conflicted_text,
-      "conflicted" => translation.conflicted,
-      "removed" => translation.removed,
-      "value_type" => translation.value_type
+      previous_translation: PreviousTranslation.from_translation(current_translation)
     }
   end
 end

--- a/lib/movement/migration/conflict.ex
+++ b/lib/movement/migration/conflict.ex
@@ -13,7 +13,7 @@ defmodule Movement.Migration.Conflict do
 
   def call(:uncorrect, operation) do
     update(operation.translation, %{
-      conflicted_text: operation.previous_translation["conflicted_text"],
+      conflicted_text: operation.previous_translation && operation.previous_translation.conflicted_text,
       conflicted: true
     })
   end
@@ -25,7 +25,7 @@ defmodule Movement.Migration.Conflict do
       file_index: operation.file_index,
       proposed_text: operation.text,
       corrected_text: operation.text,
-      conflicted_text: operation.previous_translation["corrected_text"],
+      conflicted_text: operation.previous_translation && operation.previous_translation.corrected_text,
       conflicted: true
     })
   end
@@ -36,7 +36,7 @@ defmodule Movement.Migration.Conflict do
       file_comment: operation.file_comment,
       file_index: operation.file_index,
       corrected_text: operation.text,
-      conflicted_text: operation.previous_translation["conflicted_text"],
+      conflicted_text: operation.previous_translation && operation.previous_translation.conflicted_text,
       conflicted: true
     })
   end
@@ -48,7 +48,7 @@ defmodule Movement.Migration.Conflict do
       file_index: operation.file_index,
       proposed_text: operation.text,
       corrected_text: operation.text,
-      conflicted_text: operation.previous_translation["corrected_text"],
+      conflicted_text: operation.previous_translation && operation.previous_translation.corrected_text,
       conflicted: true
     })
   end

--- a/lib/movement/migration/rollback.ex
+++ b/lib/movement/migration/rollback.ex
@@ -3,8 +3,6 @@ defmodule Movement.Migration.Rollback do
 
   import Movement.EctoMigrationHelper
 
-  alias Accent.PreviousTranslation
-
   def call(:new, operation) do
     update(operation, %{rollbacked: true})
     update(operation.translation, %{removed: true})
@@ -17,11 +15,11 @@ defmodule Movement.Migration.Rollback do
 
   def call(:restore, operation) do
     update(operation, %{rollbacked: true})
-    update(operation.translation, PreviousTranslation.to_translation(operation.previous_translation))
+    update(operation.translation, Map.from_struct(operation.previous_translation))
   end
 
   def call(:rollback, operation) do
     update(operation, %{rollbacked: false})
-    update(operation.translation, PreviousTranslation.to_translation(operation.previous_translation))
+    update(operation.translation, Map.from_struct(operation.previous_translation))
   end
 end

--- a/lib/movement/migration/translation.ex
+++ b/lib/movement/migration/translation.ex
@@ -3,7 +3,7 @@ defmodule Movement.Migration.Translation do
 
   import Movement.EctoMigrationHelper
 
-  alias Accent.{PreviousTranslation, Translation, Operation}
+  alias Accent.{Translation, Operation}
 
   def call(:update_proposed, operation) do
     operation.translation
@@ -19,7 +19,7 @@ defmodule Movement.Migration.Translation do
     |> update(%{
       value_type: operation.value_type,
       corrected_text: operation.text,
-      conflicted_text: operation.previous_translation["corrected_text"]
+      conflicted_text: operation.previous_translation && operation.previous_translation.corrected_text
     })
   end
 
@@ -51,7 +51,7 @@ defmodule Movement.Migration.Translation do
       value_type: operation.value_type,
       file_index: operation.file_index,
       file_comment: operation.file_comment,
-      removed: Map.get(operation.previous_translation, "removed", false),
+      removed: operation.previous_translation && operation.previous_translation.removed,
       revision_id: operation.revision_id,
       document_id: operation.document_id,
       version_id: operation.version_id
@@ -73,7 +73,7 @@ defmodule Movement.Migration.Translation do
       value_type: operation.value_type,
       file_index: operation.file_index,
       file_comment: operation.file_comment,
-      removed: Map.get(operation.previous_translation, "removed", false),
+      removed: operation.previous_translation && operation.previous_translation.removed,
       revision_id: operation.revision_id,
       document_id: operation.document_id,
       version_id: operation.version_id,
@@ -88,6 +88,6 @@ defmodule Movement.Migration.Translation do
 
   def call(:restore, operation) do
     update(operation, %{rollbacked: false})
-    update(operation.translation, PreviousTranslation.to_translation(operation.previous_translation))
+    update(operation.translation, Map.from_struct(operation.previous_translation))
   end
 end

--- a/lib/movement/operation.ex
+++ b/lib/movement/operation.ex
@@ -13,7 +13,7 @@ defmodule Movement.Operation do
             version_id: nil,
             document_id: nil,
             project_id: nil,
-            previous_translation: %{}
+            previous_translation: nil
 
   @type t :: %__MODULE__{}
 end

--- a/lib/web/views/peek_view.ex
+++ b/lib/web/views/peek_view.ex
@@ -25,7 +25,7 @@ defmodule Accent.PeekView do
       text: operation.text,
       key: operation.key,
       action: operation.action,
-      "previous-text": operation.previous_translation["corrected_text"] || operation.previous_translation["proposed_text"]
+      "previous-text": operation.previous_translation.corrected_text || operation.previous_translation.proposed_text
     }
   end
 

--- a/test/movement/builders/new_slave_test.exs
+++ b/test/movement/builders/new_slave_test.exs
@@ -7,6 +7,7 @@ defmodule AccentTest.Movement.Builders.NewSlave do
   alias Accent.{
     Repo,
     Translation,
+    PreviousTranslation,
     User,
     Language,
     Document
@@ -91,13 +92,13 @@ defmodule AccentTest.Movement.Builders.NewSlave do
                document_id: document.id,
                file_index: 2,
                file_comment: "comment",
-               previous_translation: %{
-                 "value_type" => nil,
-                 "removed" => true,
-                 "conflicted" => false,
-                 "conflicted_text" => "",
-                 "corrected_text" => "A",
-                 "proposed_text" => "A"
+               previous_translation: %PreviousTranslation{
+                 value_type: nil,
+                 removed: true,
+                 conflicted: false,
+                 conflicted_text: "",
+                 corrected_text: "A",
+                 proposed_text: "A"
                }
              }
            ]

--- a/test/movement/builders/rollback_test.exs
+++ b/test/movement/builders/rollback_test.exs
@@ -6,6 +6,7 @@ defmodule AccentTest.Movement.Builders.Rollback do
   alias Accent.{
     Repo,
     Translation,
+    PreviousTranslation,
     Operation,
     User,
     Language,
@@ -85,13 +86,13 @@ defmodule AccentTest.Movement.Builders.Rollback do
     assert new_operation.project_id === operation.project_id
     assert new_operation.document_id === operation.document_id
 
-    assert new_operation.previous_translation === %{
-             "value_type" => translation.value_type,
-             "proposed_text" => translation.proposed_text,
-             "corrected_text" => translation.corrected_text,
-             "conflicted_text" => translation.conflicted_text,
-             "conflicted" => translation.conflicted,
-             "removed" => translation.removed
+    assert new_operation.previous_translation === %PreviousTranslation{
+             value_type: translation.value_type,
+             proposed_text: translation.proposed_text,
+             corrected_text: translation.corrected_text,
+             conflicted_text: translation.conflicted_text,
+             conflicted: translation.conflicted,
+             removed: translation.removed
            }
   end
 end

--- a/test/movement/persisters/base_test.exs
+++ b/test/movement/persisters/base_test.exs
@@ -8,6 +8,7 @@ defmodule AccentTest.Movement.Persisters.Base do
   alias Accent.{
     Repo,
     Translation,
+    PreviousTranslation,
     Revision,
     Operation
   }
@@ -109,8 +110,8 @@ defmodule AccentTest.Movement.Persisters.Base do
         action: "new",
         key: "a",
         text: "B",
-        previous_translation: %{
-          "removed" => true
+        previous_translation: %PreviousTranslation{
+          removed: true
         }
       }
     ]

--- a/test/web/controllers/peek_controller_test.exs
+++ b/test/web/controllers/peek_controller_test.exs
@@ -161,13 +161,13 @@ defmodule AccentTest.PeekController do
              %{
                "action" => "new",
                "key" => "test2",
-               "previous-text" => nil,
+               "previous-text" => "",
                "text" => "D"
              },
              %{
                "action" => "new",
                "key" => "test3",
-               "previous-text" => nil,
+               "previous-text" => "",
                "text" => "New history please"
              }
            ]


### PR DESCRIPTION
This is a part of the code that I wanted to refactor for a long time. When Accent was created, the embedded schema in Ecto was not as documented/fully formed as of now.

This made dealing with an embedded struct so much cleaner :broom: