### PR TITLE
Make collaborator emails visible in settings

### DIFF
--- a/webapp/app/pods/components/project-settings/collaborators/list/item/component.js
+++ b/webapp/app/pods/components/project-settings/collaborators/list/item/component.js
@@ -50,14 +50,6 @@ export default Component.extend({
     return this.i18n.t(`general.roles.${this.collaborator.role}`);
   }),
 
-  fullnameWithFallback: computed('hasJoined', function() {
-    if (this.hasJoined) {
-      return this.collaborator.user.fullname;
-    } else {
-      return this.collaborator.email;
-    }
-  }),
-
   actions: {
     deleteCollaborator() {
       this.onDelete(this.collaborator);

--- a/webapp/app/pods/components/project-settings/collaborators/list/item/styles.scss
+++ b/webapp/app/pods/components/project-settings/collaborators/list/item/styles.scss
@@ -39,6 +39,11 @@
   font-size: 15px;
 }
 
+.user-email {
+  display: block;
+  font-size: 12px;
+}
+
 .user-picture {
   width: 17px;
   height: 17px;

--- a/webapp/app/pods/components/project-settings/collaborators/list/item/template.hbs
+++ b/webapp/app/pods/components/project-settings/collaborators/list/item/template.hbs
@@ -18,7 +18,18 @@
         <img class="user-picture" src="{{collaborator.user.pictureUrl}}" />
       {{/if}}
 
-      {{fullnameWithFallback}}
+      <span class="user-name">
+        {{#if hasJoined}}
+          {{#if collaborator.user.fullname}}
+            {{collaborator.user.fullname}}
+            <small class="user-email">{{collaborator.email}}</small>
+          {{else}}
+            {{collaborator.email}}
+          {{/if}}
+        {{else}}
+          {{collaborator.email}}
+        {{/if}}
+      </span>
     </span>
   </div>
 


### PR DESCRIPTION
We were only displaying a collaborator email _before_ the invitation was claimed. Now, we’re displaying it even after.

Since the email address is the user’s canonical authentication information, I think it’s best we make it more visible 😄 

### Before
<img width="629" alt="" src="https://user-images.githubusercontent.com/11348/38927361-84d7c150-42d3-11e8-96a5-11925a21ceae.png">

### After
<img width="629" alt="" src="https://user-images.githubusercontent.com/11348/38927360-84c7f6e4-42d3-11e8-9a80-bf4df819e8cd.png">