### PR TITLE
Add plural and locked state for translations

### DIFF
--- a/lib/accent/schemas/operation.ex
+++ b/lib/accent/schemas/operation.ex
@@ -31,6 +31,8 @@ defmodule Accent.Operation do
     field(:file_index, :integer)
 
     field(:value_type, :string)
+    field(:plural, :boolean, default: false)
+    field(:locked, :boolean, default: false)
 
     field(:rollbacked, :boolean, default: false)
     field(:stats, {:array, :map}, default: [])
@@ -49,8 +51,6 @@ defmodule Accent.Operation do
 
     has_one(:rollback_operation, Accent.Operation, foreign_key: :rollbacked_operation_id)
     has_many(:operations, Accent.Operation, foreign_key: :batch_operation_id)
-
-    field(:language_id, :string, virtual: true)
 
     timestamps()
   end

--- a/lib/accent/schemas/translation.ex
+++ b/lib/accent/schemas/translation.ex
@@ -14,6 +14,8 @@ defmodule Accent.Translation do
     field(:file_index, :integer)
 
     field(:value_type, :string, default: "string")
+    field(:plural, :boolean, default: false)
+    field(:locked, :boolean, default: false)
 
     belongs_to(:document, Accent.Document)
     belongs_to(:revision, Accent.Revision)

--- a/lib/accent/scopes/translation.ex
+++ b/lib/accent/scopes/translation.ex
@@ -53,6 +53,15 @@ defmodule Accent.Scopes.Translation do
   @doc """
   ## Examples
 
+    iex> Accent.Scopes.Translation.not_locked(Accent.Translation)
+    #Ecto.Query<from t in Accent.Translation, where: t.locked == false>
+  """
+  @spec not_locked(Ecto.Queryable.t()) :: Ecto.Queryable.t()
+  def not_locked(query), do: from(t in query, where: [locked: false])
+
+  @doc """
+  ## Examples
+
     iex> Accent.Scopes.Translation.parse_conflicted(Accent.Translation, nil)
     Accent.Translation
     iex> Accent.Scopes.Translation.parse_conflicted(Accent.Translation, false)

--- a/lib/accent/translations/translations_counter.ex
+++ b/lib/accent/translations/translations_counter.ex
@@ -24,6 +24,7 @@ defmodule Accent.TranslationsCounter do
     scope =
       Translation
       |> Scope.active()
+      |> Scope.not_locked()
       |> Scope.no_version()
 
     conflicted =

--- a/lib/graphql/resolvers/translation.ex
+++ b/lib/graphql/resolvers/translation.ex
@@ -103,6 +103,7 @@ defmodule Accent.GraphQL.Resolvers.Translation do
     translations =
       Translation
       |> TranslationScope.active()
+      |> TranslationScope.not_locked()
       |> TranslationScope.from_revision(revision.id)
       |> TranslationScope.from_search(args[:query])
       |> TranslationScope.from_document(args[:document] || :all)

--- a/lib/graphql/types/translation.ex
+++ b/lib/graphql/types/translation.ex
@@ -20,6 +20,7 @@ defmodule Accent.GraphQL.Types.Translation do
     field(:id, non_null(:id))
     field(:key, non_null(:string), resolve: &Accent.GraphQL.Resolvers.Translation.key/3)
     field(:value_type, non_null(:translation_value_type))
+    field(:plural, non_null(:boolean))
 
     field(:proposed_text, :string)
     field(:corrected_text, :string)

--- a/lib/langue/entry.ex
+++ b/lib/langue/entry.ex
@@ -1,3 +1,3 @@
 defmodule Langue.Entry do
-  defstruct key: nil, value: nil, comment: nil, index: 1, value_type: "string"
+  defstruct key: nil, value: nil, comment: nil, index: 1, value_type: "string", locked: false, plural: false
 end

--- a/lib/langue/formatter/gettext/parser.ex
+++ b/lib/langue/formatter/gettext/parser.ex
@@ -1,8 +1,6 @@
 defmodule Langue.Formatter.Gettext.Parser do
   @behaviour Langue.Formatter.Parser
 
-  @plural_value_type "plural"
-
   alias Langue.Entry
 
   def parse(%{render: render}) do
@@ -30,7 +28,8 @@ defmodule Langue.Formatter.Gettext.Parser do
       comment: join_string(translation.comments),
       key: join_string(translation.msgid) <> key_suffix("_"),
       value: join_string(translation.msgid_plural),
-      value_type: @plural_value_type
+      plural: true,
+      locked: true
     }
 
     translation.msgstr
@@ -40,7 +39,8 @@ defmodule Langue.Formatter.Gettext.Parser do
           index: index,
           key: join_string(translation.msgid) <> key_suffix(plural_index),
           value: join_string(value),
-          value_type: @plural_value_type
+          plural: true,
+          value_type: Langue.ValueType.parse(join_string(value))
         }
       ])
     end)

--- a/lib/langue/value_type.ex
+++ b/lib/langue/value_type.ex
@@ -1,0 +1,8 @@
+defmodule Langue.ValueType do
+  def parse(value) when is_boolean(value) or value == "false" or value == "true", do: "boolean"
+  def parse(""), do: "empty"
+  def parse(value) when value in [:null, "nil"], do: "null"
+  def parse(value) when is_integer(value), do: "integer"
+  def parse(value) when is_float(value), do: "float"
+  def parse(_), do: "string"
+end

--- a/lib/movement/builders/new_slave.ex
+++ b/lib/movement/builders/new_slave.ex
@@ -27,7 +27,9 @@ defmodule Movement.Builders.NewSlave do
           file_index: translation.file_index,
           document_id: translation.document_id,
           version_id: translation.version_id,
-          value_type: translation.value_type
+          value_type: translation.value_type,
+          plural: translation.plural,
+          locked: translation.locked
         })
       end)
 

--- a/lib/movement/builders/revision_correct_all.ex
+++ b/lib/movement/builders/revision_correct_all.ex
@@ -28,6 +28,7 @@ defmodule Movement.Builders.RevisionCorrectAll do
     translations =
       Translation
       |> TranslationScope.active()
+      |> TranslationScope.not_locked()
       |> TranslationScope.conflicted()
       |> TranslationScope.from_revision(assigns[:revision].id)
       |> Repo.all()

--- a/lib/movement/builders/revision_uncorrect_all.ex
+++ b/lib/movement/builders/revision_uncorrect_all.ex
@@ -28,6 +28,7 @@ defmodule Movement.Builders.RevisionUncorrectAll do
     translations =
       Translation
       |> TranslationScope.active()
+      |> TranslationScope.not_locked()
       |> TranslationScope.not_conflicted()
       |> TranslationScope.from_revision(assigns[:revision].id)
       |> Repo.all()

--- a/lib/movement/builders/slave_conflict_sync.ex
+++ b/lib/movement/builders/slave_conflict_sync.ex
@@ -36,6 +36,7 @@ defmodule Movement.Builders.SlaveConflictSync do
     translations =
       Translation
       |> TranslationScope.active()
+      |> TranslationScope.not_locked()
       |> TranslationScope.from_revisions(assigns[:revision_ids])
       |> TranslationScope.from_keys(assigns[:translation_keys])
       |> Repo.all()

--- a/lib/movement/entries_commit_processor.ex
+++ b/lib/movement/entries_commit_processor.ex
@@ -24,6 +24,8 @@ defmodule Movement.EntriesCommitProcessor do
           file_comment: entry.comment,
           file_index: entry.index,
           value_type: entry.value_type,
+          plural: entry.plural,
+          locked: entry.locked,
           revision_id: Map.get(assigns[:revision], :id)
         }
 

--- a/lib/movement/mappers/operation.ex
+++ b/lib/movement/mappers/operation.ex
@@ -9,7 +9,9 @@ defmodule Movement.Mappers.Operation do
       key: suggested_translation.key,
       file_comment: suggested_translation.file_comment,
       file_index: suggested_translation.file_index,
-      value_type: Map.get(suggested_translation, :value_type),
+      value_type: suggested_translation.value_type,
+      plural: suggested_translation.plural,
+      locked: suggested_translation.locked,
       revision_id: Map.get(suggested_translation, :revision_id),
       document_id: Map.get(suggested_translation, :document_id),
       version_id: Map.get(suggested_translation, :version_id),
@@ -28,6 +30,8 @@ defmodule Movement.Mappers.Operation do
       revision_id: Map.get(suggested_translation, :revision_id, current_translation.revision_id),
       version_id: Map.get(suggested_translation, :version_id, current_translation.version_id),
       value_type: Map.get(suggested_translation, :value_type, current_translation.value_type),
+      plural: Map.get(suggested_translation, :plural, current_translation.plural),
+      locked: Map.get(suggested_translation, :locked, current_translation.locked),
       translation_id: Map.get(current_translation, :id),
       previous_translation: PreviousTranslation.from_translation(current_translation)
     }

--- a/lib/movement/migration/translation.ex
+++ b/lib/movement/migration/translation.ex
@@ -49,6 +49,8 @@ defmodule Movement.Migration.Translation do
       corrected_text: operation.text,
       conflicted: is_nil(operation.version_id),
       value_type: operation.value_type,
+      plural: operation.plural,
+      locked: operation.locked,
       file_index: operation.file_index,
       file_comment: operation.file_comment,
       removed: operation.previous_translation && operation.previous_translation.removed,

--- a/lib/movement/operation.ex
+++ b/lib/movement/operation.ex
@@ -5,6 +5,8 @@ defmodule Movement.Operation do
             file_comment: nil,
             file_index: 0,
             value_type: nil,
+            plural: false,
+            locked: false,
             batch: false,
             translation_id: nil,
             rollbacked_operation_id: nil,

--- a/lib/movement/suggested_translation.ex
+++ b/lib/movement/suggested_translation.ex
@@ -1,4 +1,4 @@
 defmodule Movement.SuggestedTranslation do
-  @enforce_keys ~w(text key)a
-  defstruct ~w(text key file_comment file_index value_type revision_id)a
+  @enforce_keys ~w(text)a
+  defstruct ~w(text key file_comment file_index value_type revision_id plural locked)a
 end

--- a/priv/repo/migrations/20180425012351_add_plural_and_locked_to_translations_and_operations.exs
+++ b/priv/repo/migrations/20180425012351_add_plural_and_locked_to_translations_and_operations.exs
@@ -1,0 +1,15 @@
+defmodule Accent.Repo.Migrations.AddPluralAndLockedToTranslationsAndOperations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:translations) do
+      add :plural, :boolean, default: false, null: false
+      add :locked, :boolean, default: false, null: false
+    end
+
+    alter table(:operations) do
+      add :plural, :boolean, default: false, null: false
+      add :locked, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/graphql/resolvers/translation_test.exs
+++ b/test/graphql/resolvers/translation_test.exs
@@ -88,6 +88,7 @@ defmodule AccentTest.GraphQL.Resolvers.Translation do
 
   test "list revision", %{revision: revision, context: context} do
     translation = %Translation{revision_id: revision.id, conflicted: true, key: "ok", corrected_text: "bar", proposed_text: "bar"} |> Repo.insert!()
+    %Translation{revision_id: revision.id, conflicted: true, key: "hidden", corrected_text: "bar", proposed_text: "bar", locked: true} |> Repo.insert!()
 
     {:ok, result} = Resolver.list_revision(revision, %{}, context)
 

--- a/test/langue/es6_module/expectation_test.exs
+++ b/test/langue/es6_module/expectation_test.exs
@@ -26,4 +26,28 @@ defmodule AccentTest.Formatter.Es6Module.Expectation do
       ]
     end
   end
+
+  defmodule Plural do
+    use Langue.Expectation.Case
+
+    def render do
+      """
+      export default {
+        "count_something": {
+          "one": "1 item",
+          "other": "%{count} items",
+          "zero": "No items"
+        }
+      };
+      """
+    end
+
+    def entries do
+      [
+        %Entry{comment: "", index: 1, key: "count_something.one", value: "1 item", value_type: "string", plural: true},
+        %Entry{comment: "", index: 2, key: "count_something.other", value: "%{count} items", value_type: "string", plural: true},
+        %Entry{comment: "", index: 3, key: "count_something.zero", value: "No items", value_type: "string", plural: true}
+      ]
+    end
+  end
 end

--- a/test/langue/es6_module/formatter_test.exs
+++ b/test/langue/es6_module/formatter_test.exs
@@ -3,18 +3,21 @@ defmodule AccentTest.Formatter.Es6Module.Formatter do
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Es6Module.Expectation.{Simple}
+  alias AccentTest.Formatter.Es6Module.Expectation.{Simple, Plural}
   alias Langue.Formatter.Es6Module.{Parser, Serializer}
 
   @tests [
-    {:test_parse, Simple, Parser},
-    {:test_serialize, Simple, Serializer}
+    Simple,
+    Plural
   ]
 
   test "es6 module" do
-    Enum.each(@tests, fn {fun, ex, mo} ->
-      {expected, result} = apply(Accent.FormatterTestHelper, fun, [ex, mo])
-      assert expected == result
+    Enum.each(@tests, fn ex ->
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+
+      assert expected_parse == result_parse
+      assert expected_serialize == result_serialize
     end)
   end
 end

--- a/test/langue/gettext/expectation_test.exs
+++ b/test/langue/gettext/expectation_test.exs
@@ -64,9 +64,9 @@ defmodule AccentTest.Formatter.Gettext.Expectation do
     def entries do
       [
         %Entry{index: 1, key: "has already been taken", value: "est déjà pris"},
-        %Entry{index: 2, key: "should be at least n character(s).__KEY___", value: "should be at least %{count} character(s)", value_type: "plural"},
-        %Entry{index: 2, key: "should be at least n character(s).__KEY__0", value: "should be at least 0 characters", value_type: "plural"},
-        %Entry{index: 2, key: "should be at least n character(s).__KEY__1", value: "should be at least %{count} character(s)", value_type: "plural"}
+        %Entry{index: 2, key: "should be at least n character(s).__KEY___", value: "should be at least %{count} character(s)", plural: true, locked: true, value_type: "string"},
+        %Entry{index: 2, key: "should be at least n character(s).__KEY__0", value: "should be at least 0 characters", plural: true, value_type: "string"},
+        %Entry{index: 2, key: "should be at least n character(s).__KEY__1", value: "should be at least %{count} character(s)", plural: true, value_type: "string"}
       ]
     end
   end

--- a/test/langue/rails/expectation_test.exs
+++ b/test/langue/rails/expectation_test.exs
@@ -59,6 +59,28 @@ defmodule AccentTest.Formatter.Rails.Expectation do
     end
   end
 
+  defmodule PluralValues do
+    use Langue.Expectation.Case
+
+    def render do
+      """
+      "fr":
+        "count_something":
+          "one": "1 item"
+          "other": "%{count} items"
+          "zero": "No items"
+      """
+    end
+
+    def entries do
+      [
+        %Entry{comment: "", index: 1, key: "count_something.one", value: "1 item", value_type: "string", plural: true},
+        %Entry{comment: "", index: 2, key: "count_something.other", value: "%{count} items", value_type: "string", plural: true},
+        %Entry{comment: "", index: 3, key: "count_something.zero", value: "No items", value_type: "string", plural: true}
+      ]
+    end
+  end
+
   defmodule ArrayValues do
     use Langue.Expectation.Case
 

--- a/test/langue/rails/formatter_test.exs
+++ b/test/langue/rails/formatter_test.exs
@@ -3,13 +3,14 @@ defmodule AccentTest.Formatter.Rails.Formatter do
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Rails.Expectation.{EmptyValue, NestedValues, ArrayValues, IntegerValues}
+  alias AccentTest.Formatter.Rails.Expectation.{EmptyValue, NestedValues, ArrayValues, IntegerValues, PluralValues}
   alias Langue.Formatter.Rails.{Parser, Serializer}
 
   @tests [
     EmptyValue,
     NestedValues,
     ArrayValues,
+    PluralValues,
     IntegerValues
   ]
 

--- a/test/movement/builders/new_version_test.exs
+++ b/test/movement/builders/new_version_test.exs
@@ -33,6 +33,8 @@ defmodule AccentTest.Movement.Builders.NewVersion do
         corrected_text: "A",
         file_index: 2,
         file_comment: "comment",
+        plural: true,
+        locked: true,
         revision_id: revision.id,
         document_id: document.id
       }
@@ -44,7 +46,7 @@ defmodule AccentTest.Movement.Builders.NewVersion do
       |> NewVersionBuilder.build()
 
     translation_ids = context.assigns[:translations] |> Enum.map(&Map.get(&1, :id))
-    operations = context.operations |> Enum.map(&Map.take(&1, [:key, :action, :text, :document_id, :file_comment, :file_index]))
+    operations = context.operations |> Enum.map(&Map.take(&1, [:key, :action, :text, :document_id, :file_comment, :file_index, :plural, :locked]))
 
     assert translation_ids === [translation.id]
 
@@ -55,7 +57,9 @@ defmodule AccentTest.Movement.Builders.NewVersion do
                text: "A",
                document_id: document.id,
                file_index: 2,
-               file_comment: "comment"
+               file_comment: "comment",
+               plural: true,
+               locked: true
              }
            ]
   end

--- a/webapp/app/locales/en/translations.js
+++ b/webapp/app/locales/en/translations.js
@@ -643,6 +643,7 @@ export default {
       related_translations_link_title: 'Translations'
     },
     translation_splash_title: {
+      plural_label: 'plural',
       conflicted_label: 'in review',
       removed_label: 'This string was removed {{removedAt}}'
     },

--- a/webapp/app/pods/components/translation-splash-title/component.js
+++ b/webapp/app/pods/components/translation-splash-title/component.js
@@ -3,6 +3,8 @@ import {computed} from '@ember/object';
 
 import parsedKeyProperty from 'accent-webapp/computed-macros/parsed-key';
 
+const PLURAL_SUFFIX = /\.(\w)+$/;
+
 // Attributes:
 // project: Object <project>
 // translation: Object <translation>
@@ -11,5 +13,9 @@ export default Component.extend({
 
   versionParam: computed('translation.version.id', function() {
     return this.getWithDefault('translation.version.id', null);
+  }),
+
+  pluralBaseKey: computed('translation.key', function() {
+    return this.translation.key.replace(PLURAL_SUFFIX, '.');
   })
 });

--- a/webapp/app/pods/components/translation-splash-title/template.hbs
+++ b/webapp/app/pods/components/translation-splash-title/template.hbs
@@ -24,6 +24,21 @@
     {{/acc-badge}}
   {{/if}}
 
+  {{#if translation.plural}}
+    {{#acc-badge
+      link=true
+    }}
+      {{#link-to
+        'logged-in.project.revision.translations'
+        project.id
+        translation.revision.id
+        (query-params query=pluralBaseKey)
+      }}
+        {{t 'components.translation_splash_title.plural_label'}}
+      {{/link-to}}
+    {{/acc-badge}}
+  {{/if}}
+
   {{#if translation.isRemoved}}
     <div class="removedBadge">
       {{t 'components.translation_splash_title.removed_label' removedAt=(time-ago-in-words translation.updatedAt)}}

--- a/webapp/app/queries/translation.graphql
+++ b/webapp/app/queries/translation.graphql
@@ -8,6 +8,7 @@ query Translation($projectId: ID!, $translationId: ID!) {
         isConflicted
         isRemoved
         valueType
+        plural
         commentsCount
         correctedText
         conflictedText


### PR DESCRIPTION
Two new columns: `plural` 👥 , `locked` 🔒 .

## Plural 👥 

Previously, string could be marked as "plural" as its type. This did not made much sense because a string can be plural but have a complex type like a "float".

### Now!
A string can be identified as "plural" when in the context of "plural" in different formats. For now, simply checking the end of the key for `one`, `zero`, `other`, etc and special `.po` parsing is used to identify `plural` strings. 

## Locked 🔒 

Only locked strings for now are the plural key of the gettext format. But in the future, some strings could be marked as locked in the ui. Or known patterns could be automatically ignored for certain format (like `datetime` keys in Rails)

## UI 💅 

We add plural badge when necessary:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/464900/39225265-4d2656fe-4819-11e8-81b9-340b1e48bbbb.png">

The badge simply links to the listing page without the plural identifier so all related plural are listed:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/464900/39225276-60b15ce6-4819-11e8-9694-9060e875abf6.png">