### PR TITLE
Upgrade hoek dependency

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1511,6 +1511,13 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
         "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        }
       }
     },
     "bower-config": {
@@ -6975,6 +6982,13 @@
         "cryptiles": "2.0.5",
         "hoek": "2.16.3",
         "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        }
       }
     },
     "he": {
@@ -7033,9 +7047,9 @@
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -10646,6 +10660,13 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
         "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        }
       }
     },
     "socket.io": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -60,6 +60,7 @@
     "ember-source": "3.1.1",
     "ember-wormhole": "0.5.4",
     "graphql": "0.13.2",
+    "hoek": "5.0.3",
     "loader.js": "4.6.0",
     "raven-js": "3.23.3",
     "simple-fmt": "0.1.0",


### PR DESCRIPTION
[CVE-2018-3728](https://nvd.nist.gov/vuln/detail/CVE-2018-3728) — `hoek` node module before 5.0.3 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability.