### PR TITLE
Refactor langue tests setup and naming

### DIFF
--- a/lib/accent/schemas/document_format.ex
+++ b/lib/accent/schemas/document_format.ex
@@ -13,7 +13,8 @@ defmodule Accent.DocumentFormat do
     %{name: "ES6 module", slug: "es6_module", extension: "js"},
     %{name: "Android XML", slug: "android_xml", extension: "xml"},
     %{name: "Java properties", slug: "java_properties", extension: "properties"},
-    %{name: "Java properties XML", slug: "java_properties_xml", extension: "xml"}
+    %{name: "Java properties XML", slug: "java_properties_xml", extension: "xml"},
+    %{name: "CSV", slug: "csv", extension: "csv"}
   ]
 
   @doc """
@@ -21,7 +22,7 @@ defmodule Accent.DocumentFormat do
 
   ## Examples
     iex> Accent.DocumentFormat.slugs()
-    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml"]
+    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv"]
   """
   defmacro slugs, do: Enum.map(@all, &Map.get(&1, :slug))
 
@@ -38,7 +39,8 @@ defmodule Accent.DocumentFormat do
       %Accent.DocumentFormat{extension: "js", name: "ES6 module", slug: "es6_module"},
       %Accent.DocumentFormat{extension: "xml", name: "Android XML", slug: "android_xml"},
       %Accent.DocumentFormat{extension: "properties", name: "Java properties", slug: "java_properties"},
-      %Accent.DocumentFormat{extension: "xml", name: "Java properties XML", slug: "java_properties_xml"}
+      %Accent.DocumentFormat{extension: "xml", name: "Java properties XML", slug: "java_properties_xml"},
+      %Accent.DocumentFormat{extension: "csv", name: "CSV", slug: "csv"}
     ]
   """
   def all, do: Enum.map(@all, &struct(__MODULE__, &1))

--- a/lib/graphql/types/document_format.ex
+++ b/lib/graphql/types/document_format.ex
@@ -11,6 +11,7 @@ defmodule Accent.GraphQL.Types.DocumentFormat do
     value(:android_xml, as: "android_xml")
     value(:java_properties, as: "java_properties")
     value(:java_properties_xml, as: "java_properties_xml")
+    value(:csv, as: "csv")
   end
 
   object :document_format_item do

--- a/lib/langue/formatter/android/android.ex
+++ b/lib/langue/formatter/android/android.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.Android do
+  alias Langue.Formatter.Android.{Parser, Serializer}
+
+  def name, do: "android_xml"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/android/parser.ex
+++ b/lib/langue/formatter/android/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Android.Parser do
 
   alias Langue.Entry
 
-  def name, do: "android_xml"
-
   def parse(%{render: render}) do
     case :mochiweb_html.parse(render) do
       {"resources", _options, strings} ->

--- a/lib/langue/formatter/android/serializer.ex
+++ b/lib/langue/formatter/android/serializer.ex
@@ -5,8 +5,6 @@ defmodule Langue.Formatter.Android.Serializer do
   <?xml version="1.0" encoding="utf-8"?>
   """
 
-  def name, do: "android_xml"
-
   def serialize(%{entries: entries}) do
     resources =
       entries

--- a/lib/langue/formatter/csv/csv.ex
+++ b/lib/langue/formatter/csv/csv.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.CSV do
+  alias Langue.Formatter.CSV.{Parser, Serializer}
+
+  def name, do: "csv"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/csv/parser.ex
+++ b/lib/langue/formatter/csv/parser.ex
@@ -1,10 +1,8 @@
-defmodule Langue.Formatter.Csv.Parser do
+defmodule Langue.Formatter.CSV.Parser do
   @behaviour Langue.Formatter.Parser
 
   alias Langue.Formatter.SerializerResult, as: Input
   alias Langue.Formatter.ParserResult, as: Output
-
-  def name, do: "csv"
 
   @spec parse(Input.t()) :: Output.t()
   def parse(%Input{render: input}) do
@@ -18,7 +16,7 @@ defmodule Langue.Formatter.Csv.Parser do
     %Output{entries: entries}
   end
 
-  defp to_entry({[key, value], idx}) do
-    %Langue.Entry{index: idx, key: key, value: value}
+  defp to_entry({[key, value], index}) do
+    %Langue.Entry{index: index, key: key, value: value}
   end
 end

--- a/lib/langue/formatter/csv/serializer.ex
+++ b/lib/langue/formatter/csv/serializer.ex
@@ -1,7 +1,5 @@
-defmodule Langue.Formatter.Csv.Serializer do
+defmodule Langue.Formatter.CSV.Serializer do
   @behaviour Langue.Formatter.Serializer
-
-  def name, do: "csv"
 
   def serialize(%{entries: entries}) do
     data =

--- a/lib/langue/formatter/es6_module/es6_module.ex
+++ b/lib/langue/formatter/es6_module/es6_module.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.Es6Module do
+  alias Langue.Formatter.Es6Module.{Parser, Serializer}
+
+  def name, do: "es_module"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/es6_module/parser.ex
+++ b/lib/langue/formatter/es6_module/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Es6Module.Parser do
 
   alias Langue.Formatter.Json.Parser, as: JsonParser
 
-  def name, do: "es_module"
-
   def parse(%{render: render}) do
     # Remove the first "export default" line
     # Reverse the list to have quick access to bottom of the file

--- a/lib/langue/formatter/es6_module/serializer.ex
+++ b/lib/langue/formatter/es6_module/serializer.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Es6Module.Serializer do
 
   alias Langue.Formatter.Json.Serializer, as: JsonSerializer
 
-  def name, do: "es_module"
-
   def serialize(%{entries: entries}) do
     content = JsonSerializer.serialize_json(entries)
     render = "export default " <> content <> ";\n"

--- a/lib/langue/formatter/gettext/gettext.ex
+++ b/lib/langue/formatter/gettext/gettext.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.Gettext do
+  alias Langue.Formatter.Gettext.{Parser, Serializer}
+
+  def name, do: "gettext"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/gettext/parser.ex
+++ b/lib/langue/formatter/gettext/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Gettext.Parser do
 
   alias Langue.Entry
 
-  def name, do: "gettext"
-
   def parse(%{render: render}) do
     {:ok, po} = Gettext.PO.parse_string(render)
     entries = parse_translations(po)

--- a/lib/langue/formatter/gettext/serializer.ex
+++ b/lib/langue/formatter/gettext/serializer.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Gettext.Serializer do
 
   alias Langue.Utils.NestedParserHelper
 
-  def name, do: "gettext"
-
   def serialize(%{entries: entries, top_of_the_file_comment: top_of_the_file_comment, header: header, locale: locale}) do
     comments =
       top_of_the_file_comment

--- a/lib/langue/formatter/java_properties/java_properties.ex
+++ b/lib/langue/formatter/java_properties/java_properties.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.JavaProperties do
+  alias Langue.Formatter.JavaProperties.{Parser, Serializer}
+
+  def name, do: "java_properties"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/java_properties/parser.ex
+++ b/lib/langue/formatter/java_properties/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.JavaProperties.Parser do
 
   alias Langue.Utils.LineByLineHelper
 
-  def name, do: "java_properties"
-
   @prop_line_regex ~r/^(?<key>.+)=(?<value>.*)$/
 
   def parse(%{render: render}) do

--- a/lib/langue/formatter/java_properties/serializer.ex
+++ b/lib/langue/formatter/java_properties/serializer.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.JavaProperties.Serializer do
 
   alias Langue.Utils.LineByLineHelper
 
-  def name, do: "java_properties"
-
   def serialize(%{entries: entries}) do
     render =
       entries

--- a/lib/langue/formatter/java_properties_xml/java_properties_xml.ex
+++ b/lib/langue/formatter/java_properties_xml/java_properties_xml.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.JavaPropertiesXml do
+  alias Langue.Formatter.JavaPropertiesXml.{Parser, Serializer}
+
+  def name, do: "java_properties_xml"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/java_properties_xml/parser.ex
+++ b/lib/langue/formatter/java_properties_xml/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.JavaPropertiesXml.Parser do
 
   alias Langue.Utils.LineByLineHelper
 
-  def name, do: "java_properties_xml"
-
   @header """
   <?xml version="1.0" encoding="UTF-8" standalone="no"?>
   <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">

--- a/lib/langue/formatter/java_properties_xml/serializer.ex
+++ b/lib/langue/formatter/java_properties_xml/serializer.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.JavaPropertiesXml.Serializer do
 
   alias Langue.Utils.LineByLineHelper
 
-  def name, do: "java_properties_xml"
-
   def serialize(%{entries: entries}) do
     render =
       entries

--- a/lib/langue/formatter/json/json.ex
+++ b/lib/langue/formatter/json/json.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.Json do
+  alias Langue.Formatter.Json.{Parser, Serializer}
+
+  def name, do: "json"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/json/parser.ex
+++ b/lib/langue/formatter/json/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Json.Parser do
 
   alias Langue.Utils.NestedParserHelper
 
-  def name, do: "json"
-
   def parse(%{render: render}) do
     entries = parse_json(render)
 

--- a/lib/langue/formatter/json/serializer.ex
+++ b/lib/langue/formatter/json/serializer.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Json.Serializer do
 
   alias Langue.Utils.NestedSerializerHelper
 
-  def name, do: "json"
-
   def serialize(%{entries: entries}) do
     render =
       entries

--- a/lib/langue/formatter/rails/parser.ex
+++ b/lib/langue/formatter/rails/parser.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Rails.Parser do
 
   alias Langue.Utils.NestedParserHelper
 
-  def name, do: "rails_yml"
-
   def parse(%{render: render}) do
     {:ok, [content]} = :fast_yaml.decode(render)
 

--- a/lib/langue/formatter/rails/rails.ex
+++ b/lib/langue/formatter/rails/rails.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.Rails do
+  alias Langue.Formatter.Rails.{Parser, Serializer}
+
+  def name, do: "rails_yml"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/rails/serializer.ex
+++ b/lib/langue/formatter/rails/serializer.ex
@@ -5,8 +5,6 @@ defmodule Langue.Formatter.Rails.Serializer do
 
   @white_space_regex ~r/(:|-) \n/
 
-  def name, do: "rails_yml"
-
   def serialize(%{entries: entries, locale: locale}) do
     render =
       %{locale => entries}

--- a/lib/langue/formatter/simple_json/parser.ex
+++ b/lib/langue/formatter/simple_json/parser.ex
@@ -3,7 +3,5 @@ defmodule Langue.Formatter.SimpleJson.Parser do
 
   alias Langue.Formatter.Json.Parser, as: JsonParser
 
-  def name, do: "simple_json"
-
   def parse(data), do: JsonParser.parse(data)
 end

--- a/lib/langue/formatter/simple_json/serializer.ex
+++ b/lib/langue/formatter/simple_json/serializer.ex
@@ -4,8 +4,6 @@ defmodule Langue.Formatter.SimpleJson.Serializer do
   alias Langue.Utils.NestedSerializerHelper
   alias Langue.Formatter.Json.Serializer, as: JsonSerializer
 
-  def name, do: "simple_json"
-
   def serialize(%{entries: entries}) do
     render =
       entries

--- a/lib/langue/formatter/simple_json/simple_json.ex
+++ b/lib/langue/formatter/simple_json/simple_json.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.SimpleJson do
+  alias Langue.Formatter.SimpleJson.{Parser, Serializer}
+
+  def name, do: "simple_json"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/strings/parser.ex
+++ b/lib/langue/formatter/strings/parser.ex
@@ -5,8 +5,6 @@ defmodule Langue.Formatter.Strings.Parser do
 
   @prop_line_regex ~r/^(?<comment>.+)?"(?<key>.+)" ?= ?"(?<value>.*)"$/sm
 
-  def name, do: "strings"
-
   def parse(%{render: render}) do
     entries = LineByLineHelper.Parser.lines(render, @prop_line_regex, ";\n")
 

--- a/lib/langue/formatter/strings/serializer.ex
+++ b/lib/langue/formatter/strings/serializer.ex
@@ -3,8 +3,6 @@ defmodule Langue.Formatter.Strings.Serializer do
 
   alias Langue.Utils.LineByLineHelper
 
-  def name, do: "strings"
-
   def serialize(%{entries: entries}) do
     render =
       entries

--- a/lib/langue/formatter/strings/strings.ex
+++ b/lib/langue/formatter/strings/strings.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.Strings do
+  alias Langue.Formatter.Strings.{Parser, Serializer}
+
+  def name, do: "strings"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/langue.ex
+++ b/lib/langue/langue.ex
@@ -1,7 +1,7 @@
 defmodule Langue do
   @formats [
     Android,
-    Csv,
+    CSV,
     Es6Module,
     Gettext,
     JavaProperties,
@@ -12,13 +12,13 @@ defmodule Langue do
     Strings
   ]
 
-  for format <- @formats, module = Module.concat([Langue, Formatter, format, Parser]), name = module.name() do
+  for format <- @formats, module = Module.concat([Langue, Formatter, format]), name = module.name() do
     def parser_from_format(unquote(name)), do: {:ok, &unquote(module).parse(&1)}
   end
 
   def parser_from_format(_), do: {:error, :unknown_parser}
 
-  for format <- @formats, module = Module.concat([Langue, Formatter, format, Serializer]), name = module.name() do
+  for format <- @formats, module = Module.concat([Langue, Formatter, format]), name = module.name() do
     def serializer_from_format(unquote(name)), do: {:ok, &unquote(module).serialize(&1)}
   end
 

--- a/lib/langue/utils/parser.ex
+++ b/lib/langue/utils/parser.ex
@@ -4,6 +4,5 @@ defmodule Langue.Formatter.Parser do
 
   @type result :: {:ok, Output.t()} | {:error, any()}
 
-  @callback name() :: binary()
   @callback parse(Input.t()) :: result
 end

--- a/lib/langue/utils/serializer.ex
+++ b/lib/langue/utils/serializer.ex
@@ -4,6 +4,5 @@ defmodule Langue.Formatter.Serializer do
 
   @type result :: {:ok, Output.t()} | {:error, any()}
 
-  @callback name() :: binary()
   @callback serialize(Input.t()) :: result
 end

--- a/lib/web/plugs/movement_context_parser.ex
+++ b/lib/web/plugs/movement_context_parser.ex
@@ -1,7 +1,6 @@
 defmodule Accent.Plugs.MovementContextParser do
   use Plug.Builder
 
-  alias Langue
   alias Accent.{Repo, Document}
   alias Accent.Scopes.Document, as: DocumentScope
   alias Movement.Context
@@ -70,7 +69,7 @@ defmodule Accent.Plugs.MovementContextParser do
     conn
     |> serializer_result(render)
     |> case do
-      %Langue.Formatter.ParserResult{entries: entries, top_of_the_file_comment: comment, header: header} ->
+      %{entries: entries, top_of_the_file_comment: comment, header: header} ->
         document = %{context.assigns[:document] | top_of_the_file_comment: comment, header: header}
 
         context =

--- a/test/langue/android/exceptions_test.exs
+++ b/test/langue/android/exceptions_test.exs
@@ -1,0 +1,20 @@
+defmodule LangueTest.Formatter.Android.Exception do
+  use ExUnit.Case, async: true
+
+  Code.require_file("expectation_test.exs", __DIR__)
+
+  alias LangueTest.Formatter.Android.Expectation.{UnsupportedTag, RuntimeError}
+  alias Langue.Formatter.Android
+
+  test "android XML unsupported tag" do
+    {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(UnsupportedTag, Android)
+
+    assert expected_parse == result_parse
+  end
+
+  test "android XML with runtime error" do
+    {_, result_parse} = Accent.FormatterTestHelper.test_parse(RuntimeError, Android)
+
+    assert result_parse == []
+  end
+end

--- a/test/langue/android/expectation_test.exs
+++ b/test/langue/android/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.Android.Expectation do
+defmodule LangueTest.Formatter.Android.Expectation do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/android/formatter_test.exs
+++ b/test/langue/android/formatter_test.exs
@@ -1,11 +1,9 @@
-defmodule AccentTest.Formatter.Android.Formatter do
+defmodule LangueTest.Formatter.Android do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Android.Expectation.{Simple, EmptyValue, UnsupportedTag, RuntimeError, Commented, Array, ValueEscaping}
-  alias Langue.Formatter.Android.{Parser, Serializer}
-  alias Accent.FormatterTestHelper
+  alias Langue.Formatter.Android
 
   @tests [
     Simple,
@@ -15,25 +13,13 @@ defmodule AccentTest.Formatter.Android.Formatter do
     ValueEscaping
   ]
 
-  test "android XML" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.Android.Expectation, test) do
+    test "gettext #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Android)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Android)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
-  end
-
-  test "android XML unsupported tag" do
-    {expected_parse, result_parse} = FormatterTestHelper.test_parse(UnsupportedTag, Parser)
-
-    assert expected_parse == result_parse
-  end
-
-  test "android XML with runtime error" do
-    {_, result_parse} = FormatterTestHelper.test_parse(RuntimeError, Parser)
-
-    assert result_parse == []
+    end
   end
 end

--- a/test/langue/csv/expectation_test.exs
+++ b/test/langue/csv/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule Langue.Csv.ExpectationTest do
+defmodule Langue.Formatter.CSV.ExpectationTest do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/csv/formatter_test.exs
+++ b/test/langue/csv/formatter_test.exs
@@ -1,18 +1,18 @@
-defmodule AccentTest.Formatter.Csv.Formatter do
+defmodule Langue.Formatter.CSVTest do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias Langue.Formatter.Csv.{Parser, Serializer}
+  alias Langue.Formatter.CSV
 
   @tests [
     Simple
   ]
 
-  for test <- @tests, module = Module.concat(Langue.Csv.ExpectationTest, test) do
+  for test <- @tests, module = Module.concat(Langue.Formatter.CSV.ExpectationTest, test) do
     test "csv #{test}" do
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Serializer)
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), CSV)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), CSV)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize

--- a/test/langue/es6_module/expectation_test.exs
+++ b/test/langue/es6_module/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.Es6Module.Expectation do
+defmodule LangueTest.Formatter.Es6Module.Expectation do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/es6_module/formatter_test.exs
+++ b/test/langue/es6_module/formatter_test.exs
@@ -1,23 +1,22 @@
-defmodule AccentTest.Formatter.Es6Module.Formatter do
+defmodule LangueTest.Formatter.Es6Module do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Es6Module.Expectation.{Simple, Plural}
-  alias Langue.Formatter.Es6Module.{Parser, Serializer}
+  alias Langue.Formatter.Es6Module
 
   @tests [
     Simple,
     Plural
   ]
 
-  test "es6 module" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.Es6Module.Expectation, test) do
+    test "es6module #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Es6Module)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Es6Module)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/langue/gettext/expectation_test.exs
+++ b/test/langue/gettext/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.Gettext.Expectation do
+defmodule LangueTest.Formatter.Gettext.Expectation do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/gettext/formatter_test.exs
+++ b/test/langue/gettext/formatter_test.exs
@@ -1,44 +1,23 @@
-defmodule AccentTest.Formatter.Gettext.Parser do
+defmodule LangueTest.Formatter.Gettext do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias Accent.FormatterTestHelper
-
-  alias AccentTest.Formatter.Gettext.Expectation.{
-    DotKeys,
-    Pluralization,
-    Simple,
-    LanguageHeader
-  }
-
-  alias Langue.Formatter.Gettext.{Parser, Serializer}
+  alias Langue.Formatter.Gettext
 
   @tests [
+    Simple,
     DotKeys,
-    Pluralization,
-    Simple
+    Pluralization
   ]
 
-  for ex <- @tests do
-    test "gettext #{ex}" do
-      {expected_parse, result_parse} = FormatterTestHelper.test_parse(unquote(ex), Parser)
-      {expected_serialize, result_serialize} = FormatterTestHelper.test_serialize(unquote(ex), Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.Gettext.Expectation, test) do
+    test "gettext #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Gettext)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Gettext)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
     end
-  end
-
-  test "language in header" do
-    {_, result_serialize} = FormatterTestHelper.test_serialize(Simple, Serializer, "en")
-
-    assert result_serialize =~ "Language: en"
-  end
-
-  test "language in header when previously empty" do
-    {_, result_serialize} = FormatterTestHelper.test_serialize(LanguageHeader, Serializer, "en")
-
-    assert result_serialize =~ "Language: en"
   end
 end

--- a/test/langue/gettext/header_test.exs
+++ b/test/langue/gettext/header_test.exs
@@ -1,0 +1,24 @@
+defmodule LangueTest.Formatter.Gettext.Header do
+  use ExUnit.Case, async: true
+
+  Code.require_file("expectation_test.exs", __DIR__)
+
+  alias Langue.Formatter.Gettext
+
+  alias LangueTest.Formatter.Gettext.Expectation.{
+    Simple,
+    LanguageHeader
+  }
+
+  test "language in header" do
+    {_, result_serialize} = Accent.FormatterTestHelper.test_serialize(Simple, Gettext, "en")
+
+    assert result_serialize =~ "Language: en"
+  end
+
+  test "language in header when previously empty" do
+    {_, result_serialize} = Accent.FormatterTestHelper.test_serialize(LanguageHeader, Gettext, "en")
+
+    assert result_serialize =~ "Language: en"
+  end
+end

--- a/test/langue/java_properties/expectation_test.exs
+++ b/test/langue/java_properties/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.JavaProperties.Expectation do
+defmodule LangueTest.Formatter.JavaProperties.Expectation do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/java_properties/formatter_test.exs
+++ b/test/langue/java_properties/formatter_test.exs
@@ -1,22 +1,21 @@
-defmodule AccentTest.Formatter.JavaProperties.Formatter do
+defmodule LangueTest.Formatter.JavaProperties do
   Code.require_file("expectation_test.exs", __DIR__)
 
   use ExUnit.Case, async: true
 
-  alias AccentTest.Formatter.JavaProperties.Expectation.{Simple}
-  alias Langue.Formatter.JavaProperties.{Parser, Serializer}
+  alias Langue.Formatter.JavaProperties
 
   @tests [
     Simple
   ]
 
-  test "java properties" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.JavaProperties.Expectation, test) do
+    test "java properties #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), JavaProperties)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), JavaProperties)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/langue/java_properties_xml/expectation_test.exs
+++ b/test/langue/java_properties_xml/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.JavaPropertiesXml.Expectation do
+defmodule LangueTest.Formatter.JavaPropertiesXml.Expectation do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/java_properties_xml/formatter_test.exs
+++ b/test/langue/java_properties_xml/formatter_test.exs
@@ -1,22 +1,21 @@
-defmodule AccentTest.Formatter.JavaPropertiesXml.Formatter do
+defmodule LangueTest.Formatter.JavaPropertiesXml do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.JavaPropertiesXml.Expectation.Simple
-  alias Langue.Formatter.JavaPropertiesXml.{Parser, Serializer}
+  alias Langue.Formatter.JavaPropertiesXml
 
   @tests [
     Simple
   ]
 
-  test "java properties xml" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.JavaPropertiesXml.Expectation, test) do
+    test "java properties #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), JavaPropertiesXml)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), JavaPropertiesXml)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/langue/json/expectation_test.exs
+++ b/test/langue/json/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.Json.Expectation do
+defmodule LangueTest.Formatter.Json.Expectation do
   alias Langue.Entry
 
   defmodule Empty do

--- a/test/langue/json/formatter_test.exs
+++ b/test/langue/json/formatter_test.exs
@@ -1,10 +1,9 @@
-defmodule AccentTest.Formatter.Json.Parser do
+defmodule LangueTest.Formatter.Json do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Json.Expectation.{Empty, NilValue, EmptyValue, BooleanValue, IntegerValue, FloatValue, Simple, Nested, Complexe}
-  alias Langue.Formatter.Json.{Parser, Serializer}
+  alias Langue.Formatter.Json
 
   @tests [
     Empty,
@@ -18,13 +17,13 @@ defmodule AccentTest.Formatter.Json.Parser do
     Complexe
   ]
 
-  test "json" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.Json.Expectation, test) do
+    test "json #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Json)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Json)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/langue/rails/expectation_test.exs
+++ b/test/langue/rails/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.Rails.Expectation do
+defmodule LangueTest.Formatter.Rails.Expectation do
   alias Langue.Entry
 
   defmodule NestedValues do

--- a/test/langue/rails/formatter_test.exs
+++ b/test/langue/rails/formatter_test.exs
@@ -1,10 +1,9 @@
-defmodule AccentTest.Formatter.Rails.Formatter do
+defmodule LangueTest.Formatter.Rails do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Rails.Expectation.{EmptyValue, NestedValues, ArrayValues, IntegerValues, PluralValues}
-  alias Langue.Formatter.Rails.{Parser, Serializer}
+  alias Langue.Formatter.Rails
 
   @tests [
     EmptyValue,
@@ -14,13 +13,13 @@ defmodule AccentTest.Formatter.Rails.Formatter do
     IntegerValues
   ]
 
-  test "rails_yaml" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.Rails.Expectation, test) do
+    test "json #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Rails)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Rails)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/langue/simple_json/expectation_test.exs
+++ b/test/langue/simple_json/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.SimpleJson.Expectation do
+defmodule LangueTest.Formatter.SimpleJson.Expectation do
   alias Langue.Entry
 
   defmodule Empty do

--- a/test/langue/simple_json/formatter_test.exs
+++ b/test/langue/simple_json/formatter_test.exs
@@ -1,33 +1,33 @@
-defmodule AccentTest.Formatter.SimpleJson.Parser do
+defmodule LangueTest.Formatter.SimpleJson do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
+  alias LangueTest.Formatter.SimpleJson.Expectation.{SimpleParse, SimpleSerialize}
+  alias Langue.Formatter.SimpleJson
   alias Accent.FormatterTestHelper
-  alias AccentTest.Formatter.SimpleJson.Expectation.{Empty, SimpleParse, SimpleSerialize}
-  alias Langue.Formatter.SimpleJson.{Parser, Serializer}
 
   @tests [
     Empty
   ]
 
   test "simple json parse" do
-    {expected, result} = FormatterTestHelper.test_parse(SimpleParse, Parser)
+    {expected, result} = FormatterTestHelper.test_parse(SimpleParse, SimpleJson)
     assert expected == result
   end
 
   test "simple json serialize" do
-    {expected, result} = FormatterTestHelper.test_serialize(SimpleSerialize, Serializer)
+    {expected, result} = FormatterTestHelper.test_serialize(SimpleSerialize, SimpleJson)
     assert expected == result
   end
 
-  test "simple json" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.SimpleJson.Expectation, test) do
+    test "simple json #{test}" do
+      {expected_parse, result_parse} = FormatterTestHelper.test_parse(unquote(module), SimpleJson)
+      {expected_serialize, result_serialize} = FormatterTestHelper.test_serialize(unquote(module), SimpleJson)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/langue/strings/expectation_test.exs
+++ b/test/langue/strings/expectation_test.exs
@@ -1,4 +1,4 @@
-defmodule AccentTest.Formatter.Strings.Expectation do
+defmodule LangueTest.Formatter.Strings.Expectation do
   alias Langue.Entry
 
   defmodule Simple do

--- a/test/langue/strings/formatter_test.exs
+++ b/test/langue/strings/formatter_test.exs
@@ -1,10 +1,9 @@
-defmodule AccentTest.Formatter.Strings.Formatter do
+defmodule LangueTest.Formatter.Strings do
   use ExUnit.Case, async: true
 
   Code.require_file("expectation_test.exs", __DIR__)
 
-  alias AccentTest.Formatter.Strings.Expectation.{Simple, Commented, Multiline, EmptyValue}
-  alias Langue.Formatter.Strings.{Parser, Serializer}
+  alias Langue.Formatter.Strings
 
   @tests [
     Simple,
@@ -13,13 +12,13 @@ defmodule AccentTest.Formatter.Strings.Formatter do
     Multiline
   ]
 
-  test "strings" do
-    Enum.each(@tests, fn ex ->
-      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(ex, Parser)
-      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(ex, Serializer)
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.Strings.Expectation, test) do
+    test "strings #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), Strings)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), Strings)
 
       assert expected_parse == result_parse
       assert expected_serialize == result_serialize
-    end)
+    end
   end
 end

--- a/test/plugs/movement_context_parser_test.exs
+++ b/test/plugs/movement_context_parser_test.exs
@@ -74,7 +74,7 @@ defmodule AccentTest.Plugs.MovementContextParser do
       |> assign(:project, project)
       |> MovementContextParser.call([])
 
-    assert conn.assigns[:document_parser] == (&Langue.Formatter.Json.Parser.parse/1)
+    assert conn.assigns[:document_parser] == (&Langue.Formatter.Json.parse/1)
     assert conn.state == :unset
   end
 


### PR DESCRIPTION
Huge refactor to copy CSV and Gettext tests setup to other formats.

_Bonus 1: refactor `Langue` to call directly `Langue.Formatter.Json.parse/1` instead of `Langue.Formatter.Json.Parser.parse/1`_
_Bonus 2: adds CSV to document formats list to be able to use it in the UI_ 😉 