### PR TITLE
Laravel translation file support done in a clean branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test.json
 priv/static/webapp
 /webapp/node_modules
 /webapp/tmp
+.elixir_ls

--- a/lib/accent/schemas/document_format.ex
+++ b/lib/accent/schemas/document_format.ex
@@ -14,7 +14,8 @@ defmodule Accent.DocumentFormat do
     %{name: "Android XML", slug: "android_xml", extension: "xml"},
     %{name: "Java properties", slug: "java_properties", extension: "properties"},
     %{name: "Java properties XML", slug: "java_properties_xml", extension: "xml"},
-    %{name: "CSV", slug: "csv", extension: "csv"}
+    %{name: "CSV", slug: "csv", extension: "csv"},
+    %{name: "Laravel PHP", slug: "laravel_php", extension: "php"}
   ]
 
   @doc """
@@ -22,7 +23,7 @@ defmodule Accent.DocumentFormat do
 
   ## Examples
     iex> Accent.DocumentFormat.slugs()
-    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv"]
+    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv", "laravel_php"]
   """
   defmacro slugs, do: Enum.map(@all, &Map.get(&1, :slug))
 
@@ -40,7 +41,8 @@ defmodule Accent.DocumentFormat do
       %Accent.DocumentFormat{extension: "xml", name: "Android XML", slug: "android_xml"},
       %Accent.DocumentFormat{extension: "properties", name: "Java properties", slug: "java_properties"},
       %Accent.DocumentFormat{extension: "xml", name: "Java properties XML", slug: "java_properties_xml"},
-      %Accent.DocumentFormat{extension: "csv", name: "CSV", slug: "csv"}
+      %Accent.DocumentFormat{extension: "csv", name: "CSV", slug: "csv"},
+      %Accent.DocumentFormat{extension: "php", name: "Laravel PHP", slug: "laravel_php"}
     ]
   """
   def all, do: Enum.map(@all, &struct(__MODULE__, &1))

--- a/lib/graphql/types/document_format.ex
+++ b/lib/graphql/types/document_format.ex
@@ -12,6 +12,7 @@ defmodule Accent.GraphQL.Types.DocumentFormat do
     value(:java_properties, as: "java_properties")
     value(:java_properties_xml, as: "java_properties_xml")
     value(:csv, as: "csv")
+    value(:laravel_php, as: "laravel_php")
   end
 
   object :document_format_item do

--- a/lib/langue/formatter/laravel_php/parser.ex
+++ b/lib/langue/formatter/laravel_php/parser.ex
@@ -1,0 +1,16 @@
+defmodule Langue.Formatter.LaravelPhp.Parser do
+  @behaviour Langue.Formatter.Parser
+
+  alias Langue.Utils.NestedParserHelper
+  alias PhpAssocMap.Utils
+
+  def parse(%{render: render}) do
+    entries =
+      render
+      |> Utils.clean_up()
+      |> PhpAssocMap.to_tuple()
+      |> NestedParserHelper.parse()
+
+    %Langue.Formatter.ParserResult{entries: entries}
+  end
+end

--- a/lib/langue/formatter/laravel_php/php.ex
+++ b/lib/langue/formatter/laravel_php/php.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.LaravelPhp do
+  alias Langue.Formatter.LaravelPhp.{Parser, Serializer}
+
+  def name, do: "laravel_php"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/laravel_php/serializer.ex
+++ b/lib/langue/formatter/laravel_php/serializer.ex
@@ -1,0 +1,26 @@
+defmodule Langue.Formatter.LaravelPhp.Serializer do
+  @behaviour Langue.Formatter.Serializer
+
+  alias Langue.Utils.NestedSerializerHelper
+
+  def serialize(%{entries: entries, locale: locale}) do
+    render =
+      %{locale => entries}
+      |> Enum.with_index(-1)
+      |> Enum.map(&NestedSerializerHelper.map_value(elem(&1, 0), elem(&1, 1)))
+      |> Enum.at(0)
+      |> elem(1)
+      |> PhpAssocMap.from_tuple()
+      |> PhpAssocMap.Exploder.explode()
+
+    %Langue.Formatter.SerializerResult{render: wrap_values(render)}
+  end
+
+  @spec wrap_values(String.t()) :: String.t()
+  defp wrap_values(values) do
+    """
+    <?php
+    return #{values};
+    """
+  end
+end

--- a/lib/langue/langue.ex
+++ b/lib/langue/langue.ex
@@ -9,7 +9,8 @@ defmodule Langue do
     Json,
     Rails,
     SimpleJson,
-    Strings
+    Strings,
+    LaravelPhp
   ]
 
   for format <- @formats, module = Module.concat([Langue, Formatter, format]), name = module.name() do

--- a/mix.exs
+++ b/mix.exs
@@ -62,6 +62,7 @@ defmodule Accent.Mixfile do
       {:httpoison, "~> 1.1.0"},
       {:gettext, "~> 0.11"},
       {:csv, "~> 2.0"},
+      {:php_assoc_map, "~> 0.5"},
 
       # Errors
       {:sentry, "~> 6.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -51,6 +51,7 @@
   "phoenix_html": {:hex, :phoenix_html, "2.11.1", "77b6f7fbd252168c6ec4f573de648d37cc5258cda13266ef001fbf99267eb6f3", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.1.3", "1d178429fc8950b12457d09c6afec247bfe1fcb6f36209e18fbb0221bdfe4d41", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", [hex: :phoenix, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
+  "php_assoc_map": {:hex, :php_assoc_map, "0.5.2", "8b55283c2ffa762f8703cb30ef40085bf5c06ee08d5a82e38405fa4b949b2a6b", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_assign": {:hex, :plug_assign, "1.0.0", "368688e6acd30796237d0a2f25cd30391d28932bfcbaa7f15d7a6549c661d64b", [:mix], [{:plug, "~> 1.0.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/langue/laravel_php/expectation_test.exs
+++ b/test/langue/laravel_php/expectation_test.exs
@@ -1,0 +1,36 @@
+defmodule LangueTest.Formatter.LaravelPhp.Expectation do
+  alias Langue.Entry
+
+  defmodule ParsesDoubleQuotations do
+    use Langue.Expectation.Case
+
+    def render do
+      """
+      <?php
+      return [
+        'required'=>'Le champ :attribute est obligatoire.',
+        'required_if'=>'Le champ :attribute est obligatoire quand la valeur de :other est :value.',
+        'required_with'=>'Le champ :attribute est obligatoire quand :values est présent.',
+        'same'=>'Les champs :attribute et :other doivent être identiques.',
+        'size'=>[
+          'numeric'=>'La taille de la valeur de :attribute doit être :size.',
+          'file'=>'La taille du fichier de :attribute doit être de :size kilobytes.',
+          'string'=>'Le texte de :attribute doit contenir :size caractères.'
+          ]
+        ];
+      """
+    end
+
+    def entries do
+      [
+        %Entry{comment: "", index: 1, key: "required", value: "Le champ :attribute est obligatoire."},
+        %Entry{comment: "", index: 2, key: "required_if", value: "Le champ :attribute est obligatoire quand la valeur de :other est :value."},
+        %Entry{comment: "", index: 3, key: "required_with", value: "Le champ :attribute est obligatoire quand :values est présent."},
+        %Entry{comment: "", index: 4, key: "same", value: "Les champs :attribute et :other doivent être identiques."},
+        %Entry{comment: "", index: 5, key: "size.numeric", value: "La taille de la valeur de :attribute doit être :size."},
+        %Entry{comment: "", index: 6, key: "size.file", value: "La taille du fichier de :attribute doit être de :size kilobytes."},
+        %Entry{comment: "", index: 7, key: "size.string", value: "Le texte de :attribute doit contenir :size caractères."}
+      ]
+    end
+  end
+end

--- a/test/langue/laravel_php/formatter_test.exs
+++ b/test/langue/laravel_php/formatter_test.exs
@@ -1,0 +1,21 @@
+defmodule LangueTest.Formatter.LaravelPhp do
+  use ExUnit.Case, async: true
+
+  Code.require_file("expectation_test.exs", __DIR__)
+
+  alias Langue.Formatter.LaravelPhp
+
+  @tests [
+    ParsesDoubleQuotations
+  ]
+
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.LaravelPhp.Expectation, test) do
+    test "Laravel Php #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), LaravelPhp)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), LaravelPhp)
+
+      assert expected_parse == result_parse
+      assert expected_serialize == result_serialize
+    end
+  end
+end


### PR DESCRIPTION
Adds following support fixing #44

    Read .php associative array with either single quote ' or double quotes strings " since laravel uses both using a regular expression
    Serialize file back as double quoted string escaping double qutotes and removing single quote escapes
    @spec types specifications in method.

Also includes a basic test.

BTW, Great job on making developments so easy. Contribution in file support are pretty straight forward!

Sorry for the confusion with the other branch. 