### PR TITLE
Confirm before deleting a project.

### DIFF
--- a/webapp/app/locales/en/translations.js
+++ b/webapp/app/locales/en/translations.js
@@ -341,7 +341,8 @@ export default {
         title: 'Danger zone',
         delete_project_title: 'Delete this project',
         delete_project_text: 'Once you delete a project, there is no going back.',
-        delete_project_button: 'Delete this project'
+        delete_project_button: 'Delete this project',
+        delete_project_confirm: 'Are you sure you want to delete this project? This action cannot be undone.'
       },
       form: {
         update_button: 'Update project',

--- a/webapp/app/pods/components/project-settings/delete-form/component.js
+++ b/webapp/app/pods/components/project-settings/delete-form/component.js
@@ -1,11 +1,18 @@
 import Component from '@ember/component';
+import {inject as service} from '@ember/service';
 
 // Attributes
 // project: Object <project>
 // onSubmit: Function
 export default Component.extend({
+  i18n: service(),
+
   actions: {
     deleteProject() {
+      /* eslint-disable no-alert */
+      if (!window.confirm(this.i18n.t('components.project_settings.delete_form.delete_project_confirm'))) return;
+      /* eslint-enable no-alert */
+
       this.onSubmit();
     }
   }


### PR DESCRIPTION
I added a simple javascript confirm before deleting a project, inspired from other places in the app where there's a confirm before doing important actions.