### PR TITLE
Add Go i18n JSON document format

### DIFF
--- a/lib/accent/schemas/document_format.ex
+++ b/lib/accent/schemas/document_format.ex
@@ -15,7 +15,8 @@ defmodule Accent.DocumentFormat do
     %{name: "Java properties", slug: "java_properties", extension: "properties"},
     %{name: "Java properties XML", slug: "java_properties_xml", extension: "xml"},
     %{name: "CSV", slug: "csv", extension: "csv"},
-    %{name: "Laravel PHP", slug: "laravel_php", extension: "php"}
+    %{name: "Laravel PHP", slug: "laravel_php", extension: "php"},
+    %{name: "Go I18n JSON", slug: "go_i18n_json", extension: "json"}
   ]
 
   @doc """
@@ -23,7 +24,7 @@ defmodule Accent.DocumentFormat do
 
   ## Examples
     iex> Accent.DocumentFormat.slugs()
-    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv", "laravel_php"]
+    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv", "laravel_php", "go_i18n_json"]
   """
   defmacro slugs, do: Enum.map(@all, &Map.get(&1, :slug))
 
@@ -42,7 +43,8 @@ defmodule Accent.DocumentFormat do
       %Accent.DocumentFormat{extension: "properties", name: "Java properties", slug: "java_properties"},
       %Accent.DocumentFormat{extension: "xml", name: "Java properties XML", slug: "java_properties_xml"},
       %Accent.DocumentFormat{extension: "csv", name: "CSV", slug: "csv"},
-      %Accent.DocumentFormat{extension: "php", name: "Laravel PHP", slug: "laravel_php"}
+      %Accent.DocumentFormat{extension: "php", name: "Laravel PHP", slug: "laravel_php"},
+      %Accent.DocumentFormat{extension: "json", name: "Go I18n JSON", slug: "go_i18n_json"}
     ]
   """
   def all, do: Enum.map(@all, &struct(__MODULE__, &1))

--- a/lib/graphql/types/document_format.ex
+++ b/lib/graphql/types/document_format.ex
@@ -13,6 +13,7 @@ defmodule Accent.GraphQL.Types.DocumentFormat do
     value(:java_properties_xml, as: "java_properties_xml")
     value(:csv, as: "csv")
     value(:laravel_php, as: "laravel_php")
+    value(:go_i18n_json, as: "go_i18n_json")
   end
 
   object :document_format_item do

--- a/lib/langue/entry.ex
+++ b/lib/langue/entry.ex
@@ -1,5 +1,5 @@
 defmodule Langue.Entry do
-  defstruct key: nil, value: nil, comment: nil, index: 1, value_type: "string", locked: false, plural: false
+  defstruct key: nil, value: nil, comment: "", index: 1, value_type: "string", locked: false, plural: false
 
   @type t :: %__MODULE__{
           key: binary() | nil,

--- a/lib/langue/formatter/gettext/parser.ex
+++ b/lib/langue/formatter/gettext/parser.ex
@@ -57,7 +57,7 @@ defmodule Langue.Formatter.Gettext.Parser do
     ]
   end
 
-  defp join_string([]), do: nil
+  defp join_string([]), do: ""
   defp join_string(list), do: Enum.join(list, "\n")
 
   defp key_suffix(id), do: ".__KEY__#{id}"

--- a/lib/langue/formatter/go_i18n_json/go_i18n_json.ex
+++ b/lib/langue/formatter/go_i18n_json/go_i18n_json.ex
@@ -1,0 +1,8 @@
+defmodule Langue.Formatter.GoI18nJson do
+  alias Langue.Formatter.GoI18nJson.{Parser, Serializer}
+
+  def name, do: "go_i18n_json"
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/formatter/go_i18n_json/parser.ex
+++ b/lib/langue/formatter/go_i18n_json/parser.ex
@@ -1,0 +1,35 @@
+defmodule Langue.Formatter.GoI18nJson.Parser do
+  @behaviour Langue.Formatter.Parser
+
+  alias Langue.Entry
+
+  def parse(%{render: render}) do
+    entries =
+      render
+      |> :jiffy.decode()
+      |> Enum.flat_map(&parse_element/1)
+      |> Enum.with_index(1)
+      |> Enum.map(fn {entry, index} -> %{entry | index: index} end)
+
+    %Langue.Formatter.ParserResult{entries: entries}
+  end
+
+  defp parse_element({[{"id", key}, {"translation", {plurals}}]}) do
+    Enum.map(plurals, fn {plural_key, plural_value} ->
+      entry = fetch_entry(key <> "." <> plural_key, plural_value)
+      %{entry | plural: true}
+    end)
+  end
+
+  defp parse_element({[{"id", key}, {"translation", value}]}) do
+    [fetch_entry(key, value)]
+  end
+
+  defp fetch_entry(key, value) do
+    %Entry{
+      key: key,
+      value: to_string(value),
+      value_type: Langue.ValueType.parse(value)
+    }
+  end
+end

--- a/lib/langue/formatter/go_i18n_json/serializer.ex
+++ b/lib/langue/formatter/go_i18n_json/serializer.ex
@@ -1,0 +1,84 @@
+defmodule Langue.Formatter.GoI18nJson.Serializer do
+  @moduledoc """
+  The serializer needs to nest the plurals form inside the parent key.
+  This is done by looping over every key and keeping a `plurals` state.
+
+  When the current key is a plural we don’t append it to the entries list, but we keep it in
+  the `plurals` state.
+
+  When the current key is not a plural (and the `plurals` state is not empty),
+  we simply append the current plurals to the entries.
+  """
+
+  @behaviour Langue.Formatter.Serializer
+
+  # Constants
+  @plural_leaf ~r/\.\w+$/
+  @plural_root ~r/^\w+\./
+
+  alias Langue.Utils.NestedSerializerHelper
+
+  def serialize(%{entries: entries}) do
+    render =
+      entries
+      |> Enum.reduce(%{plurals: [], entries: []}, &process_entry/2)
+      |> append_plurals()
+      |> Map.get(:entries)
+      |> :jiffy.encode([:pretty])
+      |> Langue.Formatter.Json.Serializer.prettify_json()
+      |> Kernel.<>("\n")
+
+    %Langue.Formatter.SerializerResult{render: render}
+  end
+
+  defp process_entry(entry = %{plural: true}, acc), do: accumulate_plural(entry, acc)
+
+  defp process_entry(entry, acc) do
+    acc
+    |> append_plurals()
+    |> append_entry(entry)
+  end
+
+  defp entry_value(%{value_type: "null"}), do: :null
+  defp entry_value(entry), do: NestedSerializerHelper.entry_value_to_string(entry.value, entry.value_type)
+
+  defp accumulate_plural(entry, acc) do
+    update_in(acc, [:plurals], &(&1 ++ [entry]))
+  end
+
+  defp append_entry(acc, entry) do
+    entry = key_value(entry.key, entry_value(entry))
+
+    update_in(acc, [:entries], &(&1 ++ entry))
+  end
+
+  defp append_plurals(acc = %{plurals: []}), do: acc
+
+  defp append_plurals(acc = %{plurals: plurals}) do
+    mapped_plurals =
+      Enum.map(plurals, fn entry ->
+        {plural_to_leaf_key(entry), entry_value(entry)}
+      end)
+
+    key = plurals_to_root_key(plurals)
+    entry = key_value(key, {mapped_plurals})
+
+    update_in(acc, [:entries], &(&1 ++ entry))
+  end
+
+  # [{[{"id", "KEY"}, {"translation", "VALUE"}]}] results in the following JSON:
+  # {"id": "KEY", "translation": "VALUE"}
+  defp key_value(key, value) do
+    [{[{"id", key}, {"translation", value}]}]
+  end
+
+  # The root key is the key without the leaf: "my_key.one" will return "my_key"
+  defp plurals_to_root_key([entry | _]) do
+    String.replace(entry.key, @plural_leaf, "")
+  end
+
+  # The leaf key is the key without the root: "my_key.one" will return "one"
+  defp plural_to_leaf_key(entry) do
+    String.replace(entry.key, @plural_root, "")
+  end
+end

--- a/lib/langue/formatter/json/serializer.ex
+++ b/lib/langue/formatter/json/serializer.ex
@@ -18,7 +18,6 @@ defmodule Langue.Formatter.Json.Serializer do
     |> Enum.map(&NestedSerializerHelper.map_value(elem(&1, 0), elem(&1, 1)))
     |> List.first()
     |> elem(1)
-    |> Enum.map(&add_extra/1)
     |> encode_json()
   end
 
@@ -27,6 +26,11 @@ defmodule Langue.Formatter.Json.Serializer do
     |> Enum.map(&add_extra/1)
     |> (&{&1}).()
     |> :jiffy.encode([:pretty])
+    |> prettify_json()
+  end
+
+  def prettify_json(string) do
+    string
     |> String.replace(~r/\" : (\"|{|\[|null|false|true|\d)/, "\": \\1")
   end
 

--- a/lib/langue/langue.ex
+++ b/lib/langue/langue.ex
@@ -10,7 +10,8 @@ defmodule Langue do
     Rails,
     SimpleJson,
     Strings,
-    LaravelPhp
+    LaravelPhp,
+    GoI18nJson
   ]
 
   for format <- @formats, module = Module.concat([Langue, Formatter, format]), name = module.name() do

--- a/test/langue/android/expectation_test.exs
+++ b/test/langue/android/expectation_test.exs
@@ -133,8 +133,8 @@ defmodule LangueTest.Formatter.Android.Expectation do
 
     def entries do
       [
-        %Entry{index: 1, key: "height", value: "Height (%@)", comment: ""},
-        %Entry{index: 2, key: "agree_terms_policy", value: "By using this application, you agree to the %1$@ and %2$@.", comment: ""}
+        %Entry{index: 1, key: "height", value: "Height (%@)"},
+        %Entry{index: 2, key: "agree_terms_policy", value: "By using this application, you agree to the %1$@ and %2$@."}
       ]
     end
   end
@@ -153,7 +153,7 @@ defmodule LangueTest.Formatter.Android.Expectation do
 
     def entries do
       [
-        %Entry{index: 1, key: "a", value: "Test & 1,2,4 < > j'appelle", comment: ""}
+        %Entry{index: 1, key: "a", value: "Test & 1,2,4 < > j'appelle"}
       ]
     end
   end

--- a/test/langue/es6_module/expectation_test.exs
+++ b/test/langue/es6_module/expectation_test.exs
@@ -20,9 +20,9 @@ defmodule LangueTest.Formatter.Es6Module.Expectation do
 
     def entries do
       [
-        %Entry{index: 1, key: "general.nested", value: "value ok", comment: ""},
-        %Entry{index: 2, key: "general.roles.owner", value: "Owner", comment: ""},
-        %Entry{index: 3, key: "test", value: "OK", comment: ""}
+        %Entry{index: 1, key: "general.nested", value: "value ok"},
+        %Entry{index: 2, key: "general.roles.owner", value: "Owner"},
+        %Entry{index: 3, key: "test", value: "OK"}
       ]
     end
   end
@@ -44,9 +44,9 @@ defmodule LangueTest.Formatter.Es6Module.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "count_something.one", value: "1 item", value_type: "string", plural: true},
-        %Entry{comment: "", index: 2, key: "count_something.other", value: "%{count} items", value_type: "string", plural: true},
-        %Entry{comment: "", index: 3, key: "count_something.zero", value: "No items", value_type: "string", plural: true}
+        %Entry{index: 1, key: "count_something.one", value: "1 item", value_type: "string", plural: true},
+        %Entry{index: 2, key: "count_something.other", value: "%{count} items", value_type: "string", plural: true},
+        %Entry{index: 3, key: "count_something.zero", value: "No items", value_type: "string", plural: true}
       ]
     end
   end

--- a/test/langue/go_i18n_json/expectation_test.exs
+++ b/test/langue/go_i18n_json/expectation_test.exs
@@ -1,0 +1,55 @@
+defmodule LangueTest.Formatter.GoI18nJson.Expectation do
+  alias Langue.Entry
+
+  defmodule Simple do
+    use Langue.Expectation.Case
+
+    def render do
+      """
+      [
+        {
+          "id": "empty_string_translation",
+          "translation": ""
+        },
+        {
+          "id": "key_with_description",
+          "translation": "Check it out!"
+        },
+        {
+          "id": "key_with_line-break",
+          "translation": "This translations contains\\na line-break."
+        },
+        {
+          "id": "nested.key",
+          "translation": "This key is nested inside a namespace."
+        },
+        {
+          "id": "null_translation",
+          "translation": null
+        },
+        {
+          "id": "pluralized_key",
+          "translation": {
+            "one": "Only one pluralization found.",
+            "other": "Wow, you have %s pluralizations!",
+            "zero": "You have no pluralization."
+          }
+        }
+      ]
+      """
+    end
+
+    def entries do
+      [
+        %Entry{key: "empty_string_translation", value: "", value_type: "empty", comment: "", index: 1},
+        %Entry{key: "key_with_description", value: "Check it out! This key has a description! (At least in some formats)", comment: "", index: 2},
+        %Entry{key: "key_with_line-break", value: "This translations contains\na line-break.", comment: "", index: 3},
+        %Entry{key: "nested.key", value: "This key is nested inside a namespace.", comment: "", index: 4},
+        %Entry{key: "null_translation", value: "null", value_type: "null", comment: "", index: 5},
+        %Entry{key: "pluralized_key.one", value: "Only one pluralization found.", comment: "", index: 6, plural: true},
+        %Entry{key: "pluralized_key.other", value: "Wow, you have %s pluralizations!", comment: "", index: 7, plural: true},
+        %Entry{key: "pluralized_key.zero", value: "You have no pluralization.", comment: "", index: 8, plural: true}
+      ]
+    end
+  end
+end

--- a/test/langue/go_i18n_json/expectation_test.exs
+++ b/test/langue/go_i18n_json/expectation_test.exs
@@ -42,7 +42,7 @@ defmodule LangueTest.Formatter.GoI18nJson.Expectation do
     def entries do
       [
         %Entry{key: "empty_string_translation", value: "", value_type: "empty", comment: "", index: 1},
-        %Entry{key: "key_with_description", value: "Check it out! This key has a description! (At least in some formats)", comment: "", index: 2},
+        %Entry{key: "key_with_description", value: "Check it out!", comment: "", index: 2},
         %Entry{key: "key_with_line-break", value: "This translations contains\na line-break.", comment: "", index: 3},
         %Entry{key: "nested.key", value: "This key is nested inside a namespace.", comment: "", index: 4},
         %Entry{key: "null_translation", value: "null", value_type: "null", comment: "", index: 5},

--- a/test/langue/go_i18n_json/formatter_test.exs
+++ b/test/langue/go_i18n_json/formatter_test.exs
@@ -1,0 +1,21 @@
+defmodule LangueTest.Formatter.GoI18nJson do
+  Code.require_file("expectation_test.exs", __DIR__)
+
+  use ExUnit.Case, async: true
+
+  alias Langue.Formatter.GoI18nJson
+
+  @tests [
+    Simple
+  ]
+
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.GoI18nJson.Expectation, test) do
+    test "go i18n json #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), GoI18nJson)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), GoI18nJson)
+
+      assert expected_parse == result_parse
+      assert expected_serialize == result_serialize
+    end
+  end
+end

--- a/test/langue/java_properties/expectation_test.exs
+++ b/test/langue/java_properties/expectation_test.exs
@@ -15,10 +15,10 @@ defmodule LangueTest.Formatter.JavaProperties.Expectation do
 
     def entries do
       [
-        %Entry{key: "yes", value: "Oui", comment: "", index: 1},
-        %Entry{key: "url.hello", value: "Bonjour", comment: "", index: 2},
-        %Entry{key: "url.nested.ultra", value: "I’m so nested", comment: "", index: 3},
-        %Entry{key: "url.normal", value: "Normal string", comment: "", index: 4}
+        %Entry{key: "yes", value: "Oui", index: 1},
+        %Entry{key: "url.hello", value: "Bonjour", index: 2},
+        %Entry{key: "url.nested.ultra", value: "I’m so nested", index: 3},
+        %Entry{key: "url.normal", value: "Normal string", index: 4}
       ]
     end
   end

--- a/test/langue/java_properties_xml/expectation_test.exs
+++ b/test/langue/java_properties_xml/expectation_test.exs
@@ -21,9 +21,9 @@ defmodule LangueTest.Formatter.JavaPropertiesXml.Expectation do
     def entries do
       [
         %Entry{key: "yes", value: "Oui", comment: "  <!-- XML COMMENT -->", index: 1},
-        %Entry{key: "url.hello", value: "Bonjour", comment: "", index: 2},
-        %Entry{key: "url.nested.ultra", value: "I’m so nested", comment: "", index: 3},
-        %Entry{key: "url.normal", value: "Normal string", comment: "", index: 4}
+        %Entry{key: "url.hello", value: "Bonjour", index: 2},
+        %Entry{key: "url.nested.ultra", value: "I’m so nested", index: 3},
+        %Entry{key: "url.normal", value: "Normal string", index: 4}
       ]
     end
   end

--- a/test/langue/laravel_php/expectation_test.exs
+++ b/test/langue/laravel_php/expectation_test.exs
@@ -23,13 +23,13 @@ defmodule LangueTest.Formatter.LaravelPhp.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "required", value: "Le champ :attribute est obligatoire."},
-        %Entry{comment: "", index: 2, key: "required_if", value: "Le champ :attribute est obligatoire quand la valeur de :other est :value."},
-        %Entry{comment: "", index: 3, key: "required_with", value: "Le champ :attribute est obligatoire quand :values est présent."},
-        %Entry{comment: "", index: 4, key: "same", value: "Les champs :attribute et :other doivent être identiques."},
-        %Entry{comment: "", index: 5, key: "size.numeric", value: "La taille de la valeur de :attribute doit être :size."},
-        %Entry{comment: "", index: 6, key: "size.file", value: "La taille du fichier de :attribute doit être de :size kilobytes."},
-        %Entry{comment: "", index: 7, key: "size.string", value: "Le texte de :attribute doit contenir :size caractères."}
+        %Entry{index: 1, key: "required", value: "Le champ :attribute est obligatoire."},
+        %Entry{index: 2, key: "required_if", value: "Le champ :attribute est obligatoire quand la valeur de :other est :value."},
+        %Entry{index: 3, key: "required_with", value: "Le champ :attribute est obligatoire quand :values est présent."},
+        %Entry{index: 4, key: "same", value: "Les champs :attribute et :other doivent être identiques."},
+        %Entry{index: 5, key: "size.numeric", value: "La taille de la valeur de :attribute doit être :size."},
+        %Entry{index: 6, key: "size.file", value: "La taille du fichier de :attribute doit être de :size kilobytes."},
+        %Entry{index: 7, key: "size.string", value: "Le texte de :attribute doit contenir :size caractères."}
       ]
     end
   end

--- a/test/langue/rails/expectation_test.exs
+++ b/test/langue/rails/expectation_test.exs
@@ -18,9 +18,9 @@ defmodule LangueTest.Formatter.Rails.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "errors.model.user", value: "Utilisateur"},
-        %Entry{comment: "", index: 2, key: "errors.messages.invalid_email", value: "n’est pas une adresse courriel valide"},
-        %Entry{comment: "", index: 3, key: "errors.messages.invalid_url", value: "n’est pas un URL valide"}
+        %Entry{index: 1, key: "errors.model.user", value: "Utilisateur"},
+        %Entry{index: 2, key: "errors.messages.invalid_email", value: "n’est pas une adresse courriel valide"},
+        %Entry{index: 3, key: "errors.messages.invalid_url", value: "n’est pas un URL valide"}
       ]
     end
   end
@@ -37,7 +37,7 @@ defmodule LangueTest.Formatter.Rails.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "test", value: "", value_type: "empty"}
+        %Entry{index: 1, key: "test", value: "", value_type: "empty"}
       ]
     end
   end
@@ -54,7 +54,7 @@ defmodule LangueTest.Formatter.Rails.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "count_somehting", value: "282", value_type: "integer"}
+        %Entry{index: 1, key: "count_somehting", value: "282", value_type: "integer"}
       ]
     end
   end
@@ -74,9 +74,9 @@ defmodule LangueTest.Formatter.Rails.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "count_something.one", value: "1 item", value_type: "string", plural: true},
-        %Entry{comment: "", index: 2, key: "count_something.other", value: "%{count} items", value_type: "string", plural: true},
-        %Entry{comment: "", index: 3, key: "count_something.zero", value: "No items", value_type: "string", plural: true}
+        %Entry{index: 1, key: "count_something.one", value: "1 item", value_type: "string", plural: true},
+        %Entry{index: 2, key: "count_something.other", value: "%{count} items", value_type: "string", plural: true},
+        %Entry{index: 3, key: "count_something.zero", value: "No items", value_type: "string", plural: true}
       ]
     end
   end
@@ -103,12 +103,12 @@ defmodule LangueTest.Formatter.Rails.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "errors.__KEY__0", value: "First error"},
-        %Entry{comment: "", index: 2, key: "errors.__KEY__1", value: "Second error"},
-        %Entry{comment: "", index: 3, key: "errors.__KEY__2.nested.__KEY__0", value: "of course"},
-        %Entry{comment: "", index: 4, key: "errors.__KEY__2.nested.__KEY__1.nested_agin.__KEY__0", value: "ok"},
-        %Entry{comment: "", index: 5, key: "errors.__KEY__2.nested.__KEY__2", value: "it works"},
-        %Entry{comment: "", index: 6, key: "root", value: "AWESOME"}
+        %Entry{index: 1, key: "errors.__KEY__0", value: "First error"},
+        %Entry{index: 2, key: "errors.__KEY__1", value: "Second error"},
+        %Entry{index: 3, key: "errors.__KEY__2.nested.__KEY__0", value: "of course"},
+        %Entry{index: 4, key: "errors.__KEY__2.nested.__KEY__1.nested_agin.__KEY__0", value: "ok"},
+        %Entry{index: 5, key: "errors.__KEY__2.nested.__KEY__2", value: "it works"},
+        %Entry{index: 6, key: "root", value: "AWESOME"}
       ]
     end
   end

--- a/test/langue/simple_json/expectation_test.exs
+++ b/test/langue/simple_json/expectation_test.exs
@@ -26,10 +26,10 @@ defmodule LangueTest.Formatter.SimpleJson.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "test", value: "F"},
-        %Entry{comment: "", index: 2, key: "test2", value: "D"},
-        %Entry{comment: "", index: 3, key: "test3", value: "New history please"},
-        %Entry{comment: "", index: 4, key: "test4.key", value: "value"}
+        %Entry{index: 1, key: "test", value: "F"},
+        %Entry{index: 2, key: "test2", value: "D"},
+        %Entry{index: 3, key: "test3", value: "New history please"},
+        %Entry{index: 4, key: "test4.key", value: "value"}
       ]
     end
   end
@@ -50,10 +50,10 @@ defmodule LangueTest.Formatter.SimpleJson.Expectation do
 
     def entries do
       [
-        %Entry{comment: "", index: 1, key: "test", value: "F"},
-        %Entry{comment: "", index: 2, key: "test2", value: "D"},
-        %Entry{comment: "", index: 3, key: "test3", value: "New history please"},
-        %Entry{comment: "", index: 4, key: "test4.key", value: "value"}
+        %Entry{index: 1, key: "test", value: "F"},
+        %Entry{index: 2, key: "test2", value: "D"},
+        %Entry{index: 3, key: "test3", value: "New history please"},
+        %Entry{index: 4, key: "test4.key", value: "value"}
       ]
     end
   end

--- a/test/langue/strings/expectation_test.exs
+++ b/test/langue/strings/expectation_test.exs
@@ -13,8 +13,8 @@ defmodule LangueTest.Formatter.Strings.Expectation do
 
     def entries do
       [
-        %Entry{key: "greeting", value: "hello", comment: "", index: 1},
-        %Entry{key: "goodbye", value: "Bye bye", comment: "", index: 2}
+        %Entry{key: "greeting", value: "hello", index: 1},
+        %Entry{key: "goodbye", value: "Bye bye", index: 2}
       ]
     end
   end
@@ -31,8 +31,8 @@ defmodule LangueTest.Formatter.Strings.Expectation do
 
     def entries do
       [
-        %Entry{key: "greeting", value: "", comment: "", index: 1, value_type: "empty"},
-        %Entry{key: "goodbye", value: "Bye bye", comment: "", index: 2}
+        %Entry{key: "greeting", value: "", index: 1, value_type: "empty"},
+        %Entry{key: "goodbye", value: "Bye bye", index: 2}
       ]
     end
   end
@@ -61,7 +61,7 @@ defmodule LangueTest.Formatter.Strings.Expectation do
         %Entry{key: "app.login.text", value: "Enter your credentials below to login", comment: "/*\n  Login text\n*/", index: 1},
         %Entry{key: "app.login.text", value: "Username", comment: "\n/// Onboarding", index: 2},
         %Entry{key: "app.users.active", value: "Just one user online", comment: "\n/* User state */", index: 3},
-        %Entry{key: "app.users.unactive", value: "No users online", comment: "", index: 4}
+        %Entry{key: "app.users.unactive", value: "No users online", index: 4}
       ]
     end
   end
@@ -84,8 +84,8 @@ defmodule LangueTest.Formatter.Strings.Expectation do
 
     def entries do
       [
-        %Entry{key: "app.feedback", value: "\n      Comment:\n      \\n\\n\\n\n      ---\n      \\n\\nDevice information:\n      \\n\\nDevice: BLA\n", comment: "", index: 1},
-        %Entry{key: "app.login.text", value: "Username", comment: "", index: 2}
+        %Entry{key: "app.feedback", value: "\n      Comment:\n      \\n\\n\\n\n      ---\n      \\n\\nDevice information:\n      \\n\\nDevice: BLA\n", index: 1},
+        %Entry{key: "app.login.text", value: "Username", index: 2}
       ]
     end
   end


### PR DESCRIPTION
This adds the `Go i18n JSON` document format from this library https://github.com/nicksnyder/go-i18n

<img width="911" alt="image" src="https://user-images.githubusercontent.com/464900/42141528-c45093be-7d77-11e8-9824-3a0cd47cdd2c.png">

Pretty simple to add, I also refactored some things:

- Extract JSON helper to prettify the output
- Remove useless `comment: ""` from all expectations