### PR TITLE
Update Spanish slug to match other languages

### DIFF
--- a/priv/repo/languages.json
+++ b/priv/repo/languages.json
@@ -2501,7 +2501,7 @@
   },
   {
     "name": "Spanish",
-    "slug": "es-ES",
+    "slug": "es",
     "iso_639_1": "es",
     "iso_639_3": "spa",
     "locale": "es-ES",


### PR DESCRIPTION
Other languages (ex: `fr`, `en`, `de` and many others) have a version where the slug is only the first 2 characters without a region.

I'm pretty sure this file was generated from some source, but I haven't been able to find it. Let me know if this change make sense.