### PR TITLE
Upgrade to alpine:3.9 and add the missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN cd /opt/build && \
 #
 # Step 2 - Build a lean runtime container
 #
-FROM alpine:3.8
+FROM alpine:3.9
 
 ARG APP_NAME
 ARG APP_VERSION
@@ -56,7 +56,7 @@ ENV APP_NAME=${APP_NAME} \
 # Update kernel and install runtime dependencies
 RUN apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk --no-cache add bash openssl yaml-dev nodejs npm
+    apk --no-cache add bash openssl ca-certificates erlang-crypto yaml-dev nodejs npm
 
 WORKDIR /opt/accent
 


### PR DESCRIPTION
fixes #70 

`elixir:1.7-alpine` was updated to `erlang:21-alpine` which is now based on `alpine:3.9`. A few dependencies now needs to be explicitly added with `apk` to the runtime Alpine image.

# Result

```shell
> docker-compose up -d postgresql
Creating network "accent_default" with the default driver
Creating accent-postgres ... done
> docker-compose up application
accent-postgres is up-to-date
Recreating accent ... done
Attaching to accent
accent         | Starting dependencies…
accent         | Starting repos…
accent         | Running migrations for accent
accent         | 18:14:35.060 [info] Already up
accent         | Running seed script for accent
accent         | Success!
accent         | WARNING: Node v10.14.2 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.
accent         | Could not start watchman
accent         | Visit https://ember-cli.com/user-guide/#watchman for more info.
accent         | 18:14:37.854 [info] Running Accent.Endpoint with cowboy 2.6.1 at http://localhost:4000
```