### PR TITLE
Update elixir buildpack config to install matching elixir version

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,8 +1,8 @@
 # Erlang version
-erlang_version=20.2.1
+erlang_version=21.2
 
 # Elixir version
-elixir_version=1.7.4
+elixir_version=1.8.1
 
 # Always rebuild from scratch on every deploy?
 always_rebuild=false


### PR DESCRIPTION
The buildpack was not matching the required version of Elixir anymore, resulting in:
```
remote: -----> Compiling
remote: ** (Mix) You're trying to run :accent on Elixir v1.7.4 but it has declared in its mix.exs file it supports only Elixir ~> 1.8
remote:  !     Push rejected, failed to compile Elixir app.
```
When deploying to Heroku.