### PR TITLE
Add basic support for XLIFF 1.2 file format

### DIFF
--- a/lib/accent/schemas/document_format.ex
+++ b/lib/accent/schemas/document_format.ex
@@ -16,7 +16,8 @@ defmodule Accent.DocumentFormat do
     %{name: "Java properties XML", slug: "java_properties_xml", extension: "xml"},
     %{name: "CSV", slug: "csv", extension: "csv"},
     %{name: "Laravel PHP", slug: "laravel_php", extension: "php"},
-    %{name: "Go I18n JSON", slug: "go_i18n_json", extension: "json"}
+    %{name: "Go I18n JSON", slug: "go_i18n_json", extension: "json"},
+    %{name: "XLIFF 1.2", slug: "xliff_1_2", extension: "xlf"}
   ]
 
   @doc """
@@ -24,7 +25,7 @@ defmodule Accent.DocumentFormat do
 
   ## Examples
     iex> Accent.DocumentFormat.slugs()
-    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv", "laravel_php", "go_i18n_json"]
+    ["simple_json", "json", "strings", "gettext", "rails_yml", "es6_module", "android_xml", "java_properties", "java_properties_xml", "csv", "laravel_php", "go_i18n_json", "xliff_1_2"]
   """
   defmacro slugs, do: Enum.map(@all, &Map.get(&1, :slug))
 
@@ -44,7 +45,8 @@ defmodule Accent.DocumentFormat do
       %Accent.DocumentFormat{extension: "xml", name: "Java properties XML", slug: "java_properties_xml"},
       %Accent.DocumentFormat{extension: "csv", name: "CSV", slug: "csv"},
       %Accent.DocumentFormat{extension: "php", name: "Laravel PHP", slug: "laravel_php"},
-      %Accent.DocumentFormat{extension: "json", name: "Go I18n JSON", slug: "go_i18n_json"}
+      %Accent.DocumentFormat{extension: "json", name: "Go I18n JSON", slug: "go_i18n_json"},
+      %Accent.DocumentFormat{extension: "xlf", name: "XLIFF 1.2", slug: "xliff_1_2"}
     ]
   """
   def all, do: Enum.map(@all, &struct(__MODULE__, &1))

--- a/lib/accent/translations/translations_renderer.ex
+++ b/lib/accent/translations/translations_renderer.ex
@@ -3,18 +3,26 @@ defmodule Accent.TranslationsRenderer do
 
   def render(args) do
     value_map = Map.get(args, :value_map, & &1.corrected_text)
-    serializer = fetch_serializer(args[:document_format])
-    entries = fetch_entries(args[:translations], value_map)
+    serializer = fetch_serializer(args[:document].format)
+    master_translations = Enum.group_by(args[:master_translations], & &1.key)
+    entries = fetch_entries(args[:translations], master_translations, value_map)
 
-    parser_result = %Langue.Formatter.ParserResult{
+    serialzier_input = %Langue.Formatter.ParserResult{
       entries: entries,
-      language: args[:language],
-      top_of_the_file_comment: args[:document_top_of_the_file_comment],
-      header: args[:document_header]
+      language: %Langue.Language{
+        slug: args[:language].slug,
+        plural_forms: args[:language].plural_forms
+      },
+      document: %Langue.Document{
+        path: args[:document].path,
+        master_language: args[:master_revision].language.slug,
+        top_of_the_file_comment: args[:document].top_of_the_file_comment,
+        header: args[:document].header
+      }
     }
 
     try do
-      serializer.(parser_result)
+      serializer.(serialzier_input)
     rescue
       _ -> Langue.Formatter.SerializerResult.empty()
     end
@@ -26,9 +34,12 @@ defmodule Accent.TranslationsRenderer do
     end
   end
 
-  defp fetch_entries(translations, value_map) do
+  defp fetch_entries(translations, master_translations, value_map) do
     Enum.map(translations, fn translation ->
+      master_translation = Map.get(master_translations, translation.key)
+
       %Langue.Entry{
+        master_value: fetch_master_value(master_translation, value_map),
         key: translation.key,
         value: value_map.(translation),
         comment: translation.file_comment,
@@ -36,5 +47,12 @@ defmodule Accent.TranslationsRenderer do
         value_type: translation.value_type
       }
     end)
+  end
+
+  defp fetch_master_value(nil, _), do: nil
+  defp fetch_master_value([], _), do: nil
+
+  defp fetch_master_value([master_translation], value_map) do
+    value_map.(master_translation)
   end
 end

--- a/lib/graphql/types/document_format.ex
+++ b/lib/graphql/types/document_format.ex
@@ -14,6 +14,7 @@ defmodule Accent.GraphQL.Types.DocumentFormat do
     value(:csv, as: "csv")
     value(:laravel_php, as: "laravel_php")
     value(:go_i18n_json, as: "go_i18n_json")
+    value(:xliff_1_2, as: "xliff_1_2")
   end
 
   object :document_format_item do

--- a/lib/langue/document.ex
+++ b/lib/langue/document.ex
@@ -1,0 +1,3 @@
+defmodule Langue.Document do
+  defstruct path: nil, header: nil, top_of_the_file_comment: nil, master_language: nil
+end

--- a/lib/langue/entry.ex
+++ b/lib/langue/entry.ex
@@ -1,5 +1,5 @@
 defmodule Langue.Entry do
-  defstruct key: nil, value: nil, comment: nil, index: 1, value_type: "string", locked: false, plural: false, placeholders: []
+  defstruct key: nil, master_value: nil, value: nil, comment: nil, index: 1, value_type: "string", locked: false, plural: false, placeholders: []
 
   @type t :: %__MODULE__{
           key: binary() | nil,

--- a/lib/langue/formatter/gettext/parser.ex
+++ b/lib/langue/formatter/gettext/parser.ex
@@ -4,7 +4,7 @@ defmodule Langue.Formatter.Gettext.Parser do
   alias Langue.Entry
   alias Langue.Utils.Placeholders
 
-  def parse(%{render: render}) do
+  def parse(%{render: render, document: document}) do
     {:ok, po} = Gettext.PO.parse_string(render)
     entries = parse_translations(po)
     top_of_the_file_comment = join_string(po.top_of_the_file_comments)
@@ -12,8 +12,11 @@ defmodule Langue.Formatter.Gettext.Parser do
 
     %Langue.Formatter.ParserResult{
       entries: entries,
-      top_of_the_file_comment: top_of_the_file_comment,
-      header: header
+      document: %{
+        document
+        | top_of_the_file_comment: top_of_the_file_comment,
+          header: header
+      }
     }
   end
 

--- a/lib/langue/formatter/gettext/serializer.ex
+++ b/lib/langue/formatter/gettext/serializer.ex
@@ -3,14 +3,14 @@ defmodule Langue.Formatter.Gettext.Serializer do
 
   alias Langue.Utils.NestedParserHelper
 
-  def serialize(%{entries: entries, top_of_the_file_comment: top_of_the_file_comment, header: header, language: language}) do
+  def serialize(%{entries: entries, document: document, language: language}) do
     comments =
-      top_of_the_file_comment
+      document.top_of_the_file_comment
       |> String.trim()
       |> String.split("\n", trim: true)
 
     headers =
-      header
+      document.header
       |> String.trim()
       |> String.replace("\"", "")
       |> replace_language_header(language)

--- a/lib/langue/formatter/parser_result.ex
+++ b/lib/langue/formatter/parser_result.ex
@@ -2,7 +2,7 @@ defmodule Langue.Formatter.ParserResult do
   @type t :: struct
 
   @enforce_keys [:entries]
-  defstruct entries: [], top_of_the_file_comment: "", header: "", language: nil
+  defstruct entries: [], document: nil, language: nil
 
   def empty, do: %__MODULE__{entries: []}
 end

--- a/lib/langue/formatter/serializer_result.ex
+++ b/lib/langue/formatter/serializer_result.ex
@@ -2,7 +2,7 @@ defmodule Langue.Formatter.SerializerResult do
   @type t :: struct
 
   @enforce_keys [:render]
-  defstruct render: ""
+  defstruct render: "", document: nil
 
   def empty, do: %__MODULE__{render: ""}
 end

--- a/lib/langue/formatter/xliff_1_2/parser.ex
+++ b/lib/langue/formatter/xliff_1_2/parser.ex
@@ -1,0 +1,41 @@
+defmodule Langue.Formatter.XLIFF12.Parser do
+  @behaviour Langue.Formatter.Parser
+
+  alias Langue.Entry
+  alias Langue.Utils.Placeholders
+
+  def parse(%{render: render}) do
+    render
+    |> :erlsom.simple_form()
+    |> case do
+      {:ok, {'file', _attributes, [{'body', _, body}]}, _} ->
+        entries =
+          body
+          |> Enum.with_index(1)
+          |> Enum.map(&parse_line/1)
+          |> Enum.reject(&is_nil/1)
+          |> Placeholders.parse(Langue.Formatter.XLIFF12.placeholder_regex())
+
+        %Langue.Formatter.ParserResult{entries: entries}
+
+      _ ->
+        Langue.Formatter.ParserResult.empty()
+    end
+  end
+
+  defp parse_line({{'trans-unit', [{'id', key}], [{'source', [], [source]}, {'target', [], [value]}]}, index}) do
+    key = IO.chardata_to_string(key)
+    value = IO.chardata_to_string(value)
+    source = IO.chardata_to_string(source)
+
+    %Entry{
+      value: value,
+      master_value: source,
+      value_type: Langue.ValueType.parse(value),
+      key: key,
+      index: index
+    }
+  end
+
+  defp parse_line(_), do: nil
+end

--- a/lib/langue/formatter/xliff_1_2/serializer.ex
+++ b/lib/langue/formatter/xliff_1_2/serializer.ex
@@ -1,0 +1,63 @@
+defmodule Langue.Formatter.XLIFF12.Serializer do
+  @behaviour Langue.Formatter.Serializer
+
+  def serialize(%{entries: entries, language: %{slug: slug}, document: %{master_language: master_language, path: path}}) when slug === master_language do
+    file_attributes = [
+      original: path,
+      datatype: "plaintext",
+      "source-language": master_language
+    ]
+
+    body = [
+      {"body", [], Enum.map(entries, &parse_master/1)}
+    ]
+
+    serialize_body(file_attributes, body)
+  end
+
+  def serialize(%{entries: entries, language: language, document: document}) do
+    file_attributes = [
+      original: document.path,
+      datatype: "plaintext",
+      "source-language": document.master_language,
+      "target-language": language.slug
+    ]
+
+    body = [
+      {"body", [], Enum.map(entries, &parse_target/1)}
+    ]
+
+    serialize_body(file_attributes, body)
+  end
+
+  defp serialize_body(file_attributes, body) do
+    render =
+      {"file", file_attributes, body}
+      |> XmlBuilder.generate()
+      |> Kernel.<>("\n")
+
+    %Langue.Formatter.SerializerResult{render: render}
+  end
+
+  defp parse_target(%{key: key, master_value: master_value, value: value}) do
+    {
+      "trans-unit",
+      [id: key],
+      [
+        {"source", [], master_value},
+        {"target", [], value}
+      ]
+    }
+  end
+
+  defp parse_master(%{key: key, value: value}) do
+    {
+      "trans-unit",
+      [id: key],
+      [
+        {"source", [], value},
+        {"target", [], ""}
+      ]
+    }
+  end
+end

--- a/lib/langue/formatter/xliff_1_2/xliff_1_2.ex
+++ b/lib/langue/formatter/xliff_1_2/xliff_1_2.ex
@@ -1,0 +1,11 @@
+defmodule Langue.Formatter.XLIFF12 do
+  @behaviour Langue.Formatter
+
+  alias Langue.Formatter.XLIFF12.{Parser, Serializer}
+
+  def name, do: "xliff_1_2"
+  def placeholder_regex, do: :not_supported
+
+  defdelegate parse(map), to: Parser
+  defdelegate serialize(map), to: Serializer
+end

--- a/lib/langue/language.ex
+++ b/lib/langue/language.ex
@@ -1,0 +1,3 @@
+defmodule Langue.Language do
+  defstruct slug: nil, plural_forms: nil
+end

--- a/lib/langue/langue.ex
+++ b/lib/langue/langue.ex
@@ -11,7 +11,8 @@ defmodule Langue do
     SimpleJson,
     Strings,
     LaravelPhp,
-    GoI18nJson
+    GoI18nJson,
+    XLIFF12
   ]
 
   for format <- @formats, module = Module.concat([Langue, Formatter, format]), name = module.name() do

--- a/lib/movement/persisters/project_sync.ex
+++ b/lib/movement/persisters/project_sync.ex
@@ -3,7 +3,7 @@ defmodule Movement.Persisters.ProjectSync do
 
   import Movement.Context, only: [assign: 3]
 
-  alias Accent.{Project, Repo}
+  alias Accent.{Document, Project, Repo}
   alias Movement.Persisters.Base, as: BasePersister
 
   @batch_action "sync"
@@ -27,10 +27,12 @@ defmodule Movement.Persisters.ProjectSync do
     end)
   end
 
+  defp persist_document(context = %Movement.Context{assigns: %{document_update: nil, document: %{id: id}}}) when not is_nil(id), do: context
+
   defp persist_document(context = %Movement.Context{assigns: %{document_update: document_update, document: document = %{id: id}}}) when not is_nil(id) do
     document =
       document
-      |> Accent.Document.changeset(document_update)
+      |> Document.changeset(document_update)
       |> Repo.update!()
 
     assign(context, :document, document)
@@ -41,7 +43,7 @@ defmodule Movement.Persisters.ProjectSync do
   defp persist_document(context = %Movement.Context{assigns: %{document: document}}) do
     document =
       document
-      |> Accent.Document.changeset(%{})
+      |> Document.changeset(%{})
       |> Repo.insert!()
 
     assign(context, :document, document)

--- a/lib/web/controllers/export_jipt_controller.ex
+++ b/lib/web/controllers/export_jipt_controller.ex
@@ -114,11 +114,11 @@ defmodule Accent.ExportJIPTController do
 
     %{render: render} =
       Accent.TranslationsRenderer.render(%{
+        master_translations: [],
         translations: translations,
+        master_revision: Enum.at(project.revisions, 0),
         language: Enum.at(project.revisions, 0).language,
-        document_format: document.format,
-        document_top_of_the_file_comment: document.top_of_the_file_comment,
-        document_header: document.header,
+        document: document,
         value_map: &"{^#{&1.key}@#{document.path}}"
       })
 

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,8 @@ defmodule Accent.Mixfile do
       {:csv, "~> 2.0"},
       {:php_assoc_map, "~> 0.5"},
       {:jason, "~> 1.0"},
+      {:erlsom, "~> 1.5"},
+      {:xml_builder, "~> 2.0"},
 
       # Errors
       {:sentry, "~> 7.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -25,6 +25,7 @@
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "3.0.7", "44dda84ac6b17bbbdeb8ac5dfef08b7da253b37a453c34ab1a98de7f7e5fec7f", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "ecto_sql": {:hex, :ecto_sql, "3.0.5", "7e44172b4f7aca4469f38d7f6a3da394dbf43a1bcf0ca975e958cb957becd74e", [:mix], [{:db_connection, "~> 2.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.0.6", [hex: :ecto, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.9.1", [hex: :mariaex, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.14.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.3.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "erlsom": {:hex, :erlsom, "1.5.0", "c5a5cdd0ee0e8dca62bcc4b13ff08da24fdefc16ccd8b25282a2fda2ba1be24a", [:rebar3], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.5", "7c912c4ec0715a6013647d835c87cde8154855b9b84e256bc7a63858d5f284e3", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
@@ -71,4 +72,5 @@
   "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
+  "xml_builder": {:hex, :xml_builder, "2.1.1", "2d6d665f09cf1319e3e1c46035755271b414d99ad8615d0bd6f337623e0c885b", [:mix], [], "hexpm"},
 }

--- a/test/langue/xliff_1_2/expectation_test.exs
+++ b/test/langue/xliff_1_2/expectation_test.exs
@@ -1,0 +1,31 @@
+defmodule LangueTest.Formatter.XLIFF12.Expectation do
+  alias Langue.Entry
+
+  defmodule Simple do
+    use Langue.Expectation.Case
+
+    def render do
+      """
+      <file original="project-a" datatype="plaintext" source-language="en" target-language="fr">
+        <body>
+          <trans-unit id="greeting">
+            <source>hello</source>
+            <target>bonjour</target>
+          </trans-unit>
+          <trans-unit id="goodbye">
+            <source>Bye bye</source>
+            <target>À la prochaine</target>
+          </trans-unit>
+        </body>
+      </file>
+      """
+    end
+
+    def entries do
+      [
+        %Entry{key: "greeting", value: "bonjour", master_value: "hello", index: 1},
+        %Entry{key: "goodbye", value: "À la prochaine", master_value: "Bye bye", index: 2}
+      ]
+    end
+  end
+end

--- a/test/langue/xliff_1_2/formatter_test.exs
+++ b/test/langue/xliff_1_2/formatter_test.exs
@@ -1,0 +1,21 @@
+defmodule LangueTest.Formatter.XLIFF12 do
+  use ExUnit.Case, async: true
+
+  Code.require_file("expectation_test.exs", __DIR__)
+
+  alias Langue.Formatter.XLIFF12
+
+  @tests [
+    Simple
+  ]
+
+  for test <- @tests, module = Module.concat(LangueTest.Formatter.XLIFF12.Expectation, test) do
+    test "xliff 1.2 #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(module), XLIFF12)
+      {expected_serialize, result_serialize} = Accent.FormatterTestHelper.test_serialize(unquote(module), XLIFF12)
+
+      assert expected_parse == result_parse
+      assert expected_serialize == result_serialize
+    end
+  end
+end

--- a/test/plugs/movement_context_parser_test.exs
+++ b/test/plugs/movement_context_parser_test.exs
@@ -156,7 +156,10 @@ defmodule AccentTest.Plugs.MovementContextParser do
     assert context.assigns[:document] == %Document{
              project_id: project.id,
              path: "hello",
-             format: "gettext",
+             format: "gettext"
+           }
+
+    assert context.assigns[:document_update] == %{
              top_of_the_file_comment:
                "## Do not add, change, or remove `msgid`s manually here as\n## they're tied to the ones in the corresponding POT file\n## (with the same domain).\n##\n## Use `mix gettext.extract --merge` or `mix gettext.merge`\n## to merge POT files into PO files.",
              header: "\nLanguage: fr\n"

--- a/test/services/translations_renderer_test.exs
+++ b/test/services/translations_renderer_test.exs
@@ -43,8 +43,10 @@ defmodule AccentTest.TranslationsRenderer do
 
     %{render: render} =
       TranslationsRenderer.render(%{
+        master_translations: [],
+        master_revision: revision,
         translations: [translation],
-        document_format: document.format,
+        document: document,
         language: revision.language
       })
 
@@ -81,8 +83,10 @@ defmodule AccentTest.TranslationsRenderer do
 
     %{render: render} =
       TranslationsRenderer.render(%{
+        master_translations: [],
+        master_revision: revision,
         translations: translations,
-        document_format: document.format,
+        document: document,
         language: revision.language
       })
 
@@ -104,8 +108,10 @@ defmodule AccentTest.TranslationsRenderer do
 
     %{render: render} =
       TranslationsRenderer.render(%{
+        master_translations: [],
+        master_revision: revision,
         translations: [translation],
-        document_format: document.format,
+        document: document,
         language: %Language{slug: "fr"}
       })
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,19 +1,33 @@
 defmodule Accent.FormatterTestHelper do
   def test_parse(variant, parser) do
-    context = %Langue.Formatter.SerializerResult{render: variant.render} |> parser.parse
+    context =
+      %Langue.Formatter.SerializerResult{
+        render: variant.render,
+        document: %Langue.Document{
+          path: "project-a",
+          master_language: "en",
+          top_of_the_file_comment: variant.top_of_the_file_comment,
+          header: variant.header
+        }
+      }
+      |> parser.parse()
 
     {variant.entries, context.entries}
   end
 
-  def test_serialize(variant, serializer, language \\ %Accent.Language{slug: "fr"}) do
+  def test_serialize(variant, serializer, language \\ %Langue.Language{slug: "fr"}) do
     context =
       %Langue.Formatter.ParserResult{
         entries: variant.entries,
         language: language,
-        top_of_the_file_comment: variant.top_of_the_file_comment,
-        header: variant.header
+        document: %Langue.Document{
+          path: "project-a",
+          master_language: "en",
+          top_of_the_file_comment: variant.top_of_the_file_comment,
+          header: variant.header
+        }
       }
-      |> serializer.serialize
+      |> serializer.serialize()
 
     {variant.render, context.render}
   end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/464900/55203015-35c17980-51a0-11e9-8647-d91209c7b6de.png)

## Issue
📚 https://github.com/mirego/accent/issues/21

## Feature
This is a basic implementation of the XLIFF 1.2 format. This format is used heavily in a lot of translations related tool (and in XCode) so I may have missed some of the implementation details. But it’s a good start for someone who want to contribute to Accent 😉 

## Refactor
This format is a bit trickier than other since it required the master language to export the targets. We needed to refactor some module to use the master language in the serialization process. Also, not needed but cleaner, we wrap the document’s key `top_of_the_file_comment` and `header` inside a new struct `Language.Document`. This will become handy if we ever need to add an attribute to the document OR if we add a different attribute to the serialization input.

## Next steps
This format includes 2 new dependencies to handle XML encode and decode. _Why not use the same XML library used for the XML Android format?_ Because… \*drum roll\* The `<source>` XML tag when encoded by the `mochiweb_html` module is a self closing tag (per the HTML spec) 🥇 

Since those 2 new deps are required for the XLIFF format and can pretty print XML, we should use them _instead of `mochiweb`_ 🎉 
