### PR TITLE
Bump Node and NPM version to the current LTS

### DIFF
--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -5,10 +5,10 @@ clean_cache=false
 compile="compile"
 
 # We can set the version of Node to use for the app here
-node_version=9.5.0
+node_version=10.16.0
 
 # We can set the version of NPM to use for the app here
-npm_version=6.1.0
+npm_version=6.9.0
 
 # We can set the path to phoenix app. E.g. apps/phoenix_app when in umbrella.
 phoenix_relative_path=.


### PR DESCRIPTION
While this is not strictly required, Ember complained that the version on Node used was too old. I bumped it to the current LTS version and used the matching NPM version.