### PR TITLE
Add support for msgctxt

### DIFF
--- a/lib/langue/formatter/gettext/parser.ex
+++ b/lib/langue/formatter/gettext/parser.ex
@@ -50,7 +50,7 @@ defmodule Langue.Formatter.Gettext.Parser do
     end)
   end
 
-  defp parse_translation(translation) do
+  defp parse_translation(translation = %{msgctxt: nil}) do
     [
       %Entry{
         comment: join_string(translation.comments),
@@ -60,8 +60,22 @@ defmodule Langue.Formatter.Gettext.Parser do
     ]
   end
 
+  defp parse_translation(translation) do
+    [
+      %Entry{
+        comment: join_string(translation.comments),
+        key: join_string(translation.msgid) <> context_suffix(translation.msgctxt),
+        value: join_string(translation.msgstr)
+      }
+    ]
+  end
+
   defp join_string([]), do: nil
   defp join_string(list), do: Enum.join(list, "\n")
 
   defp key_suffix(id), do: ".__KEY__#{id}"
+
+  defp context_suffix(""), do: ""
+
+  defp context_suffix(id), do: ".__CONTEXT__#{id}"
 end

--- a/lib/langue/formatter/gettext/serializer.ex
+++ b/lib/langue/formatter/gettext/serializer.ex
@@ -45,11 +45,22 @@ defmodule Langue.Formatter.Gettext.Serializer do
   end
 
   defp do_parse_entries({_key, [entry]}) do
-    %Gettext.PO.Translation{
-      comments: split_string(entry.comment, []),
-      msgid: split_string(entry.key),
-      msgstr: split_string(entry.value)
-    }
+    case Regex.named_captures(~r/(?<id>.*)\.__CONTEXT__(?<context>.*)/, entry.key) do
+      %{"id" => id, "context" => context} ->
+        %Gettext.PO.Translation{
+          comments: split_string(entry.comment, []),
+          msgid: split_string(id),
+          msgstr: split_string(entry.value),
+          msgctxt: split_string(context)
+        }
+
+      _ ->
+        %Gettext.PO.Translation{
+          comments: split_string(entry.comment, []),
+          msgid: split_string(entry.key),
+          msgstr: split_string(entry.value)
+        }
+    end
   end
 
   defp do_parse_entries({_key, [plural_entry | entries]}) do

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule Accent.Mixfile do
       {:jsone, "~> 1.4"},
       {:mochiweb, "~> 2.18"},
       {:httpoison, "~> 1.1.0"},
-      {:gettext, "~> 0.11"},
+      {:gettext, github: "elixir-lang/gettext"},
       {:csv, "~> 2.0"},
       {:php_assoc_map, "~> 0.5"},
       {:jason, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -36,7 +36,7 @@
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "gen_smtp": {:hex, :gen_smtp, "0.12.0", "97d44903f5ca18ca85cb39aee7d9c77e98d79804bbdef56078adcf905cb2ef00", [:rebar3], [], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.14.2", "6a2a578a510c5bfca8a45e6b27552f613b41cf584b58210f017088d3d17d0b14", [:mix], [], "hexpm"},
-  "gettext": {:hex, :gettext, "0.17.0", "abe21542c831887a2b16f4c94556db9c421ab301aee417b7c4fbde7fbdbe01ec", [:mix], [], "hexpm"},
+  "gettext": {:git, "https://github.com/elixir-lang/gettext.git", "8f729835968ce14349a92cf0437ed850f88ac6de", []},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.1.1", "96ed7ab79f78a31081bb523eefec205fd2900a02cda6dbc2300e7a1226219566", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/langue/gettext/expectation_test.exs
+++ b/test/langue/gettext/expectation_test.exs
@@ -270,4 +270,26 @@ defmodule LangueTest.Formatter.Gettext.Expectation do
       """)
     end
   end
+
+  defmodule ContextValues do
+    use Langue.Expectation.Case
+
+    def render do
+      """
+      msgid "test duplicate"
+      msgstr "a"
+
+      msgctxt "other"
+      msgid "test duplicate"
+      msgstr "a"
+      """
+    end
+
+    def entries do
+      [
+        %Entry{index: 1, key: "test duplicate", value: "a"},
+        %Entry{index: 2, key: "test duplicate.__CONTEXT__other", value: "a"}
+      ]
+    end
+  end
 end

--- a/test/langue/gettext/formatter_test.exs
+++ b/test/langue/gettext/formatter_test.exs
@@ -12,7 +12,8 @@ defmodule LangueTest.Formatter.Gettext do
     PlaceholderValues,
     LanguageHeader,
     PluralFormsHeader,
-    HeaderLineBreak
+    HeaderLineBreak,
+    ContextValues
   ]
 
   for test <- @tests, module = Module.concat(LangueTest.Formatter.Gettext.Expectation, test) do


### PR DESCRIPTION
Second attempt to integrate context. With msgctxt from gettext as the first implementation.

This is in regards to:
#113 