### PR TITLE
Convert Sass variables to CSS modules @value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,156 @@
         "@babel/highlight": "7.0.0-beta.44"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
+      "integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
+      "requires": {
+        "browserslist": "^4.8.2",
+        "invariant": "^2.2.4",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "@babel/core": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+      "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.3",
+        "@babel/helpers": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
@@ -24,6 +174,463 @@
         "lodash": "^4.2.0",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+      "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+      "requires": {
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+      "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.3.tgz",
+      "integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
+      "integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
+      "requires": {
+        "@babel/compat-data": "^7.8.1",
+        "browserslist": "^4.8.2",
+        "invariant": "^2.2.4",
+        "levenary": "^1.1.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
+      "integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
+      "integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
+      "requires": {
+        "@babel/helper-regex": "^7.8.3",
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+      "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+      "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+      "requires": {
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -46,6 +653,454 @@
         "@babel/types": "7.0.0-beta.44"
       }
     },
+    "@babel/helper-hoist-variables": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+      "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+      "requires": {
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "requires": {
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "requires": {
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
+      "integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "requires": {
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+    },
+    "@babel/helper-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+      "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
+      "requires": {
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+      "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-wrap-function": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
+      "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
@@ -53,6 +1108,239 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+      "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
+      "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+          "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+          "requires": {
+            "@babel/types": "^7.8.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+          "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.3",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
       }
     },
     "@babel/highlight": {
@@ -64,6 +1352,721 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+      "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+      "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-remap-async-to-generator": "^7.8.3",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+      "integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
+      "integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-decorators": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+      "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+      "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
+      "integrity": "sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+      "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+      "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+      "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-remap-async-to-generator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+      "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+      "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
+      "integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-define-map": "^7.8.3",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+      "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+      "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+      "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+      "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+      "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz",
+      "integrity": "sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+      "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+      "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+      "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+      "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+      "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-simple-access": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+      "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+      "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+      "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+      "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+      "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz",
+      "integrity": "sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==",
+      "requires": {
+        "@babel/helper-call-delegate": "^7.8.3",
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+      "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.3.tgz",
+      "integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
+      "requires": {
+        "regenerator-transform": "^0.14.0"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+      "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+      "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+      "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+      "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+      "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-regex": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+      "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz",
+      "integrity": "sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+      "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/polyfill": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
+      "integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.3.tgz",
+      "integrity": "sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==",
+      "requires": {
+        "@babel/compat-data": "^7.8.0",
+        "@babel/helper-compilation-targets": "^7.8.3",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+        "@babel/plugin-proposal-json-strings": "^7.8.3",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.8.3",
+        "@babel/plugin-transform-async-to-generator": "^7.8.3",
+        "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+        "@babel/plugin-transform-block-scoping": "^7.8.3",
+        "@babel/plugin-transform-classes": "^7.8.3",
+        "@babel/plugin-transform-computed-properties": "^7.8.3",
+        "@babel/plugin-transform-destructuring": "^7.8.3",
+        "@babel/plugin-transform-dotall-regex": "^7.8.3",
+        "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+        "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+        "@babel/plugin-transform-for-of": "^7.8.3",
+        "@babel/plugin-transform-function-name": "^7.8.3",
+        "@babel/plugin-transform-literals": "^7.8.3",
+        "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+        "@babel/plugin-transform-modules-amd": "^7.8.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.8.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.8.3",
+        "@babel/plugin-transform-modules-umd": "^7.8.3",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+        "@babel/plugin-transform-new-target": "^7.8.3",
+        "@babel/plugin-transform-object-super": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.8.3",
+        "@babel/plugin-transform-property-literals": "^7.8.3",
+        "@babel/plugin-transform-regenerator": "^7.8.3",
+        "@babel/plugin-transform-reserved-words": "^7.8.3",
+        "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+        "@babel/plugin-transform-spread": "^7.8.3",
+        "@babel/plugin-transform-sticky-regex": "^7.8.3",
+        "@babel/plugin-transform-template-literals": "^7.8.3",
+        "@babel/plugin-transform-typeof-symbol": "^7.8.3",
+        "@babel/plugin-transform-unicode-regex": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "browserslist": "^4.8.2",
+        "core-js-compat": "^3.6.2",
+        "invariant": "^2.2.2",
+        "levenary": "^1.1.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+      "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -112,6 +2115,15 @@
       "resolved": "https://registry.npmjs.org/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz",
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==",
       "dev": true
+    },
+    "@ember/render-modifiers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
+      }
     },
     "@glimmer/interfaces": {
       "version": "0.44.0",
@@ -185,14 +2197,18 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "12.12.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
       "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
       "dev": true
+    },
+    "@types/symlink-or-copy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+      "integrity": "sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.16.0",
@@ -340,6 +2356,15 @@
         "uri-js": "^4.2.2"
       }
     },
+    "amd-name-resolver": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.3.1.tgz",
+      "integrity": "sha512-26qTEWqZQ+cxSYygZ4Cf8tsjDBLceJahhtewxtKZA3SRa4PluuqYCuheemDQD+7Mf5B7sr+zhTDWAHDh02a1Dw==",
+      "requires": {
+        "ensure-posix-path": "^1.0.1",
+        "object-hash": "^1.3.1"
+      }
+    },
     "ansi-escapes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
@@ -391,6 +2416,11 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -424,6 +2454,72 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "requires": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "rsvp": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+        }
+      }
+    },
+    "async-promise-queue": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.5.tgz",
+      "integrity": "sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==",
+      "requires": {
+        "async": "^2.4.1",
+        "debug": "^2.6.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -444,6 +2540,49 @@
         "eslint-visitor-keys": "^1.0.0"
       }
     },
+    "babel-plugin-debug-macros": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz",
+      "integrity": "sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==",
+      "requires": {
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-ember-modules-api-polyfill": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.12.0.tgz",
+      "integrity": "sha512-ZQU4quX0TJ1yYyosPy5PFigKdCFEVHJ6H0b3hwjxekIP9CDwzk0OhQuKhCOPti+d52VWjjCjxu2BrXEih29mFw==",
+      "requires": {
+        "ember-rfc176-data": "^0.3.12"
+      }
+    },
+    "babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "requires": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      }
+    },
     "babylon": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
@@ -453,8 +2592,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -511,11 +2649,20 @@
         }
       }
     },
+    "binaryextensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.2.0.tgz",
+      "integrity": "sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw=="
+    },
+    "blank-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
+      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -550,6 +2697,175 @@
         }
       }
     },
+    "broccoli-babel-transpiler": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.4.0.tgz",
+      "integrity": "sha512-DzPXQr1C+zOgzXG40wqPjtjSSa6wRKb+Ls45Qtq7Pn+GxL3/jIvQOBZi0/irZ5dlYVbRMEZiUnaIBIOha2ygIw==",
+      "requires": {
+        "@babel/core": "^7.8.3",
+        "@babel/polyfill": "^7.8.3",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      }
+    },
+    "broccoli-debug": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
+      "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
+      "requires": {
+        "broccoli-plugin": "^1.2.1",
+        "fs-tree-diff": "^0.5.2",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "symlink-or-copy": "^1.1.8",
+        "tree-sync": "^1.2.2"
+      }
+    },
+    "broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "requires": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "broccoli-kitchen-sink-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+      "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
+      "requires": {
+        "glob": "^5.0.10",
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "requires": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      }
+    },
+    "broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "requires": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "dependencies": {
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
+        }
+      }
+    },
+    "broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "requires": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "broccoli-source": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
+    },
+    "browserslist": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
+      "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+      "requires": {
+        "caniuse-lite": "^1.0.30001022",
+        "electron-to-chromium": "^1.3.338",
+        "node-releases": "^1.1.46"
+      }
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -579,11 +2895,33 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "can-symlink": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+      "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
+      "requires": {
+        "tmp": "0.0.28"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        }
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001022",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz",
+      "integrity": "sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A=="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -594,7 +2932,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -603,7 +2940,6 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -639,6 +2975,11 @@
         }
       }
     },
+    "clean-up-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
+      "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw=="
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -654,6 +2995,11 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -668,7 +3014,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -676,8 +3021,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -688,14 +3032,42 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+    },
+    "core-js-compat": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+      "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+      "requires": {
+        "browserslist": "^4.8.3",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+        }
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -738,6 +3110,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -816,11 +3196,111 @@
         }
       }
     },
+    "editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+    },
+    "electron-to-chromium": {
+      "version": "1.3.339",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.339.tgz",
+      "integrity": "sha512-C1i/vH6/kQx9YV8RddMkmW216GwW4pTrnYIlKmDFIqXA4fPwqDxIdGyHsuG+fgurHoljRz7/oaD+tztcryW/9g=="
+    },
+    "ember-cli-babel": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.13.2.tgz",
+      "integrity": "sha512-VH2tMXaRFkbQEyVJnxUtAyta5bAKjtcLwJ4lStW/iRk/NIlNFNJh1uOd7uL9H9Vm0f4/xR7Mc0Q7ND9ezKOo+A==",
+      "requires": {
+        "@babel/core": "^7.7.0",
+        "@babel/plugin-proposal-class-properties": "^7.7.0",
+        "@babel/plugin-proposal-decorators": "^7.7.0",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-runtime": "^7.6.0",
+        "@babel/polyfill": "^7.7.0",
+        "@babel/preset-env": "^7.7.0",
+        "@babel/runtime": "^7.7.0",
+        "amd-name-resolver": "^1.2.1",
+        "babel-plugin-debug-macros": "^0.3.0",
+        "babel-plugin-ember-modules-api-polyfill": "^2.12.0",
+        "babel-plugin-module-resolver": "^3.1.1",
+        "broccoli-babel-transpiler": "^7.3.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-source": "^1.1.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ensure-posix-path": "^1.0.2",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "ember-cli-babel-plugin-helpers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz",
+      "integrity": "sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA=="
+    },
+    "ember-cli-version-checker": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+      "requires": {
+        "resolve": "^1.3.3",
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "ember-compatibility-helpers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz",
+      "integrity": "sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==",
+      "requires": {
+        "babel-plugin-debug-macros": "^0.2.0",
+        "ember-cli-version-checker": "^2.1.1",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "ember-modifier-manager-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
+      "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "ember-compatibility-helpers": "^1.2.0"
+      }
+    },
     "ember-rfc176-data": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz",
-      "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==",
-      "dev": true
+      "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g=="
     },
     "ember-template-lint": {
       "version": "1.8.2",
@@ -842,11 +3322,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "ensure-posix-path": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
+      "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "6.8.0",
@@ -1154,8 +3638,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -1336,6 +3819,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-ordered-set": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
+      "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
+      "requires": {
+        "blank-object": "^1.0.1"
+      }
+    },
     "figures": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
@@ -1377,6 +3868,30 @@
         }
       }
     },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        }
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -1409,17 +3924,49 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "requires": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "fs-updater": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fs-updater/-/fs-updater-1.0.4.tgz",
+      "integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
+      "requires": {
+        "can-symlink": "^1.0.0",
+        "clean-up-path": "^1.0.0",
+        "heimdalljs": "^0.2.5",
+        "heimdalljs-logger": "^0.1.9",
+        "rimraf": "^2.6.2"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -1437,7 +3984,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1477,8 +4023,7 @@
     "globals": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
-      "dev": true
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
     },
     "globby": {
       "version": "9.2.0",
@@ -1527,8 +4072,12 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -1559,6 +4108,58 @@
           "requires": {
             "is-buffer": "^1.1.5"
           }
+        }
+      }
+    },
+    "hash-for-dep": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.5.1.tgz",
+      "integrity": "sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==",
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "heimdalljs": "^0.2.3",
+        "heimdalljs-logger": "^0.1.7",
+        "path-root": "^0.1.1",
+        "resolve": "^1.10.0",
+        "resolve-package-path": "^1.0.11"
+      }
+    },
+    "heimdalljs": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+      "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+      "requires": {
+        "rsvp": "~3.2.1"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
+        }
+      }
+    },
+    "heimdalljs-logger": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
+      "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
+      "requires": {
+        "debug": "^2.2.0",
+        "heimdalljs": "^0.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1597,7 +4198,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1606,8 +4206,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "7.0.3",
@@ -1634,7 +4233,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -1790,11 +4388,20 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+      "requires": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -1809,8 +4416,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1818,17 +4424,58 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+    },
+    "levenary": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
+      "integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
+      "requires": {
+        "leven": "^3.1.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -1840,17 +4487,24 @@
         "type-check": "~0.3.2"
       }
     },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -1885,6 +4539,23 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "merge-trees": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+      "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+      "requires": {
+        "fs-updater": "^1.0.4",
+        "heimdalljs": "^0.2.5"
       }
     },
     "merge2": {
@@ -1924,7 +4595,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1932,8 +4602,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -1960,16 +4629,19 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
     },
+    "mktemp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -2032,6 +4704,19 @@
         }
       }
     },
+    "node-releases": {
+      "version": "1.1.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+      "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
+      "requires": {
+        "semver": "^6.3.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -2063,6 +4748,16 @@
         }
       }
     },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -2070,6 +4765,17 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.pick": {
@@ -2085,7 +4791,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2134,8 +4839,28 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -2158,11 +4883,15 @@
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -2173,8 +4902,25 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-posix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
     },
     "path-type": {
       "version": "3.0.0",
@@ -2199,6 +4945,14 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -2217,17 +4971,73 @@
       "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
       "dev": true
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-map-series": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "requires": {
+        "rsvp": "^3.0.14"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+        }
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "quick-temp": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
+      "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+      "requires": {
+        "mktemp": "~0.4.0",
+        "rimraf": "^2.5.4",
+        "underscore.string": "~3.3.4"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
+    "regenerator-transform": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+      "requires": {
+        "private": "^0.1.6"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -2245,6 +5055,39 @@
       "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
       "dev": true
     },
+    "regexpu-core": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
+    },
+    "regjsparser": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+      "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        }
+      }
+    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -2257,11 +5100,15 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
+    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
       "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -2271,6 +5118,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-package-path": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+      "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
+      "requires": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.10.0"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -2298,10 +5154,14 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -2321,6 +5181,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -2339,8 +5204,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -2560,8 +5424,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -2594,8 +5457,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -2669,6 +5531,38 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
+    "symlink-or-copy": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
+      "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA=="
+    },
+    "sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "requires": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -2712,6 +5606,11 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "textextensions": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
+      "integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -2730,8 +5629,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -2773,6 +5671,33 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "tree-sync": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.4.0.tgz",
+      "integrity": "sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==",
+      "requires": {
+        "debug": "^2.2.0",
+        "fs-tree-diff": "^0.5.6",
+        "mkdirp": "^0.5.1",
+        "quick-temp": "^0.1.5",
+        "walk-sync": "^0.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "trim-right": {
@@ -2834,6 +5759,39 @@
           "optional": true
         }
       }
+    },
+    "underscore.string": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "requires": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -2908,11 +5866,30 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "username-sync": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.2.tgz",
+      "integrity": "sha512-ayNkOJdoNSGNDBE46Nkc+l6IXmeugbzahZLSMkwvgRWv5y5ZqNY2IrzcgmkR4z32sj1W3tM3TuTUMqkqBzO+RA=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
+    },
+    "walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "requires": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -2929,11 +5906,20 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "requires": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "eslint-plugin-node": "11.0.0",
     "prettier": "1.16.4",
     "typescript": "3.7.4"
+  },
+  "dependencies": {
+    "@ember/render-modifiers": "1.0.2"
   }
 }

--- a/webapp/app/pods/components/acc-badge/styles.scss
+++ b/webapp/app/pods/components/acc-badge/styles.scss
@@ -1,54 +1,57 @@
-& {
-  transition: $transition-speed $transition-easing;
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-grey, color-green, color-error from 'accent-webapp/styles/variables/colors';
+
+.badge {
+  transition: transition-speed transition-easing;
   transition-property: background;
   display: inline-block;
   padding: 1px 6px 1px 5px;
-  background: lighten($color-grey, 28%);
+  background: lighten(color-grey, 28%);
   border-radius: 3px;
-  color: darken($color-grey, 10%);
+  color: darken(color-grey, 10%);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   text-decoration: none;
 }
 
-&.primary {
-  background: $color-green;
+.primary {
+  background: color-green;
   background: var(--color-primary);
   color: #fff;
 }
 
-&.danger {
-  background: $color-error;
+.danger {
+  background: color-error;
   color: #fff;
 }
 
-&.link {
+.link {
   padding: 0;
 
   &:focus,
   &:hover {
-    background: lighten($color-grey, 26%);
+    background: lighten(color-grey, 26%);
   }
 }
 
-&.link.primary {
+.link.primary {
   padding: 0;
 
   &:focus,
   &:hover {
-    background: darken($color-green, 3%);
+    background: darken(color-green, 3%);
     background: var(--color-primary-darken-10);
   }
 }
 
-&.link a {
+.link a {
   display: inline-block;
   padding: 1px 6px 1px 5px;
   color: lighten(#000, 50%);
   text-decoration: none;
 }
 
-&.link.primary a {
+.link.primary a {
   color: #fff;
 }

--- a/webapp/app/pods/components/acc-flash-message/styles.scss
+++ b/webapp/app/pods/components/acc-flash-message/styles.scss
@@ -1,4 +1,6 @@
-& {
+@value color-green, color-socket, color-error from 'accent-webapp/styles/variables/colors';
+
+.flash {
   position: relative;
   margin-bottom: 10px;
   width: 400px;
@@ -8,35 +10,37 @@
   text-shadow: 0 1px 1px rgba(#000, 0.1);
   color: #fff;
   font-weight: bold;
-  animation: 0.3s flash-message-in ease;
+  animation: 0.3s ease;
+  animation-name: flash-message-in;
   pointer-events: all;
 
   &.is-exiting {
-    animation: 0.3s flash-message-out forwards ease-in-out;
+    animation: 0.3s forwards ease-in-out;
+    animation-name: flash-message-out;
   }
 }
 
 &.success {
-  background: $color-green;
+  background: color-green;
 
   .icon {
-    stroke: lighten($color-green, 35%);
+    stroke: lighten(color-green, 35%);
   }
 }
 
 &.socket {
-  background: $color-socket;
+  background: color-socket;
 
   .icon {
-    stroke: lighten($color-socket, 35%);
+    stroke: lighten(color-socket, 35%);
   }
 }
 
 &.error {
-  background: $color-error;
+  background: color-error;
 
   .icon {
-    stroke: lighten($color-error, 35%);
+    stroke: lighten(color-error, 35%);
   }
 }
 

--- a/webapp/app/pods/components/activity-item/styles.scss
+++ b/webapp/app/pods/components/activity-item/styles.scss
@@ -1,4 +1,7 @@
-& {
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-border, color-light-background, color-green, color-grey, color-error, color-success, color-warning, color-black from 'accent-webapp/styles/variables/colors';
+
+.item {
   display: flex;
   position: relative;
   margin: 25px 0;
@@ -20,7 +23,7 @@
   width: calc(100% + -9px);
   padding: 5px;
   background: #fff;
-  border: 1px solid rgba($color-border, 0.5);
+  border: 1px solid rgba(color-border, 0.5);
 
   .item-iconContainer {
     top: 3px;
@@ -38,9 +41,9 @@
 
 &.sync {
   padding: 6px 10px 5px;
-  background: $color-light-background;
+  background: color-light-background;
   border-color: transparent;
-  border-left-color: $color-green;
+  border-left-color: color-green;
   border-left-color: var(--color-primary);
 
   &.compact {
@@ -51,7 +54,7 @@
 
   .item-iconContainer {
     left: -21px;
-    background: $color-green;
+    background: color-green;
     background: var(--color-primary);
     border-color: transparent;
     box-shadow: none;
@@ -63,18 +66,18 @@
 
   .item-stats {
     padding: 0;
-    background: lighten($color-green, 46%);
+    background: lighten(color-green, 46%);
     background: var(--color-primary-lighten-99);
-    color: darken($color-green, 25%);
+    color: darken(color-green, 25%);
     color: var(--color-primary-darken-50);
   }
 
   .item-date {
-    color: $color-grey;
+    color: color-grey;
   }
 
   .item-details-link {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 
@@ -84,14 +87,14 @@
   }
 
   .item-documentPath {
-    color: darken($color-green, 25%);
+    color: darken(color-green, 25%);
     color: var(--color-primary-darken-30);
     font-size: 13px;
   }
 
   .item-user,
   .item-header-content {
-    color: darken($color-green, 25%);
+    color: darken(color-green, 25%);
     color: var(--color-primary-darken-30);
     font-size: 13px;
   }
@@ -105,7 +108,7 @@
   }
 
   .item-user-icon {
-    stroke: darken($color-green, 25%);
+    stroke: darken(color-green, 25%);
     stroke: var(--color-primary);
     width: 17px;
     height: 17px;
@@ -119,7 +122,7 @@
 
   &.compact {
     .item-iconContainer-icon {
-      stroke: $color-green;
+      stroke: color-green;
       stroke: var(--color-primary);
     }
 
@@ -140,8 +143,8 @@
 }
 
 &.rollback {
-  background: $color-light-background;
-  border: 1px solid rgba($color-border, 0.3);
+  background: color-light-background;
+  border: 1px solid rgba(color-border, 0.3);
 
   .item-header {
     margin-bottom: 4px;
@@ -158,14 +161,14 @@
   .item-content {
     padding: 5px 0 0;
     margin: 0;
-    background: $color-light-background;
+    background: color-light-background;
     border-bottom: 0;
   }
 }
 
 &.uncorrect-all {
   .item-iconContainer {
-    background: $color-error;
+    background: color-error;
     border-color: transparent;
   }
 
@@ -175,7 +178,7 @@
 
   &.compact {
     .item-iconContainer-icon {
-      stroke: $color-error;
+      stroke: color-error;
     }
   }
 }
@@ -183,12 +186,12 @@
 &.correct-all {
   &.compact {
     .item-iconContainer-icon {
-      stroke: $color-success;
+      stroke: color-success;
     }
   }
 
   .item-iconContainer {
-    background: $color-success;
+    background: color-success;
     border-color: transparent;
   }
 
@@ -198,10 +201,10 @@
 }
 
 &.document-delete {
-  border-color: lighten($color-error, 35%);
+  border-color: lighten(color-error, 35%);
 
   .item-iconContainer {
-    background: $color-error;
+    background: color-error;
     border-color: transparent;
   }
 
@@ -211,48 +214,48 @@
 
   &.compact {
     .item-iconContainer-icon {
-      stroke: $color-error;
+      stroke: color-error;
     }
   }
 }
 
 &.correct-conflict {
   .item-iconContainer {
-    border-color: rgba($color-success, 0.4);
+    border-color: rgba(color-success, 0.4);
   }
 
   .item-iconContainer-icon {
-    stroke: $color-success;
+    stroke: color-success;
   }
 }
 
 &.uncorrect-conflict {
   .item-iconContainer {
-    border-color: rgba($color-error, 0.2);
+    border-color: rgba(color-error, 0.2);
   }
 
   .item-iconContainer-icon {
-    stroke: $color-error;
+    stroke: color-error;
   }
 }
 
 &.conflict-on-corrected {
   .item-iconContainer {
-    border-color: lighten($color-error, 35%);
+    border-color: lighten(color-error, 35%);
   }
 
   .item-iconContainer-icon {
-    stroke: $color-error;
+    stroke: color-error;
   }
 }
 
 &.conflict-on-proposed {
   .item-iconContainer {
-    border-color: lighten($color-warning, 25%);
+    border-color: lighten(color-warning, 25%);
   }
 
   .item-iconContainer-icon {
-    stroke: $color-warning;
+    stroke: color-warning;
   }
 }
 
@@ -272,13 +275,13 @@
 
   .item-iconContainer {
     background: #fff;
-    border-color: rgba($color-grey, 0.4);
+    border-color: rgba(color-grey, 0.4);
   }
 
   .item-iconContainer-icon {
     width: 11px;
     height: 11px;
-    stroke: rgba($color-grey, 0.5);
+    stroke: rgba(color-grey, 0.5);
   }
 
   &.rollback,
@@ -286,7 +289,7 @@
   &.new-slave,
   &.uncorrect-all,
   &.correct-all {
-    border-color: $color-border;
+    border-color: color-border;
 
     .item-iconContainer {
       left: -19px;
@@ -295,7 +298,7 @@
   }
 
   &.sync {
-    border-color: rgba($color-green, 0.1);
+    border-color: rgba(color-green, 0.1);
 
     .item-iconContainer {
       left: -19px;
@@ -421,7 +424,7 @@
   height: 21px;
   margin-right: 10px;
   border-radius: 50%;
-  border: 1px solid $color-grey;
+  border: 1px solid color-grey;
   box-shadow: 0 0 0 5px #fff;
   background: #fff;
 }
@@ -430,7 +433,7 @@
   width: 11px;
   height: 11px;
   flex: 0 0 11px;
-  stroke: $color-grey;
+  stroke: color-grey;
 }
 
 .item-content {
@@ -506,7 +509,7 @@
 .item-translationText {
   margin: 5px 0 10px;
   padding: 8px;
-  background: $color-light-background;
+  background: color-light-background;
   font-size: 12px;
   font-style: italic;
 }
@@ -536,7 +539,7 @@
 
 .item-documentPath {
   display: inline-block;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
   font-weight: bold;
   font-size: 12px;
@@ -555,12 +558,12 @@
   text-decoration: none;
   font-size: 12px;
   font-weight: bold;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
 
   &:hover,
   &:focus {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 
@@ -579,7 +582,7 @@
 .item-revisionLink {
   display: inline-block;
   text-decoration: none;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 
   &:hover,
@@ -596,7 +599,7 @@
 }
 
 .item-date {
-  color: $color-grey;
+  color: color-grey;
   font-size: 11px;
 }
 
@@ -606,18 +609,18 @@
 }
 
 .item-rollback {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: opacity, color;
   opacity: 0;
   background: none;
   padding: 0;
   margin: 0 0 0 5px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 11px;
 
   &:focus,
   &:hover {
-    color: darken($color-grey, 25%);
+    color: darken(color-grey, 25%);
     text-decoration: underline;
   }
 }
@@ -649,21 +652,21 @@
   margin-left: 5px;
   border-left: 1px solid #ddd;
   text-decoration: none;
-  color: $color-grey;
+  color: color-grey;
   font-size: 11px;
   font-weight: 500;
 
   &:focus,
   &:hover {
     text-decoration: underline;
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }
 
 .item-content-rollbacked {
   margin-bottom: 6px;
-  color: $color-error;
+  color: color-error;
   font-size: 12px;
   font-weight: 500;
 }

--- a/webapp/app/pods/components/application-footer/styles.scss
+++ b/webapp/app/pods/components/application-footer/styles.scss
@@ -1,8 +1,10 @@
-& {
+@value color-light-background, color-grey from 'accent-webapp/styles/variables/colors';
+
+.footer {
   padding: 10px;
   margin-top: 40px;
-  background: $color-light-background;
-  color: $color-grey;
+  background: color-light-background;
+  color: color-grey;
   font-size: 12px;
   text-align: right;
 }

--- a/webapp/app/pods/components/async-button/styles.scss
+++ b/webapp/app/pods/components/async-button/styles.scss
@@ -1,4 +1,7 @@
-& {
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black from 'accent-webapp/styles/variables/colors';
+
+.button {
   padding: 0;
 
   &.button--loading {
@@ -14,13 +17,13 @@
     }
   }
 
-  &.button--filled {
+  &:global(.button--filled) {
     .loading {
       fill: #fff;
     }
   }
 
-  &.button--small {
+  &:global(.button--small) {
     &.button--loading {
       .loading {
         width: 14px;
@@ -40,7 +43,7 @@
 }
 
 .label {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: transform;
   transform: translate3d(0, 0, 0);
   display: flex;
@@ -49,12 +52,12 @@
 }
 
 .loading {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: left;
   will-change: left;
   width: 15px;
   position: absolute;
   top: calc(50% - 8px);
   left: 100%;
-  fill: $color-black;
+  fill: color-black;
 }

--- a/webapp/app/pods/components/commit-file/styles.scss
+++ b/webapp/app/pods/components/commit-file/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey, color-green, color-black, color-error from 'accent-webapp/styles/variables/colors';
+
 .separator {
   display: block;
   margin: 10px 0;
@@ -9,7 +11,7 @@
 .textHelper {
   margin-bottom: 3px;
   width: 80%;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
 }
 
@@ -18,15 +20,15 @@
   margin-bottom: 7px;
   padding: 2px 4px 3px;
   border-radius: 4px;
-  background: lighten($color-green, 48%);
+  background: lighten(color-green, 48%);
   background: var(--color-primary-opacity-10);
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   font-size: 11px;
 
   &.documentHelper--new {
-    background: lighten($color-green, 48%);
-    color: $color-green;
+    background: lighten(color-green, 48%);
+    color: color-green;
   }
 }
 
@@ -35,8 +37,8 @@
   margin-bottom: 8px;
   padding: 5px;
   outline: 0;
-  border: 1px solid lighten($color-grey, 20%);
-  box-shadow: inset 0 2px 6px rgba($color-black, 0.05);
+  border: 1px solid lighten(color-grey, 20%);
+  box-shadow: inset 0 2px 6px rgba(color-black, 0.05);
   background: #fff;
   font-family: $font-monospace;
   font-size: 12px;
@@ -84,7 +86,7 @@
   width: 15px;
   height: 15px;
   margin-right: 10px;
-  stroke: $color-black;
+  stroke: color-black;
   stroke: var(--color-black);
 }
 
@@ -92,7 +94,7 @@
   display: flex;
   align-items: center;
   margin: 0 0 6px;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 }
 
@@ -101,7 +103,7 @@
   margin: 0 0 10px;
   font-size: 14px;
   font-weight: 300;
-  color: rgba($color-black, 0.7);
+  color: rgba(color-black, 0.7);
   color: var(--color-black-opacity-70);
 }
 
@@ -134,7 +136,7 @@
   margin-bottom: 5px;
   font-size: 13px;
   font-weight: bold;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 }
 
@@ -142,13 +144,13 @@
 .instructions-text {
   margin-bottom: 18px;
   font-size: 13px;
-  color: rgba($color-black, 0.5);
+  color: rgba(color-black, 0.5);
   color: var(--color-black);
 
   em {
     font-style: normal;
     font-weight: bold;
-    color: rgba($color-green, 0.8);
+    color: rgba(color-green, 0.8);
     color: var(--color-primary);
   }
 }
@@ -169,7 +171,7 @@
 
 .errorMessage {
   margin: 10px 0;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
   font-weight: bold;
 }
@@ -184,8 +186,8 @@
 
 .ember-power-select-trigger {
   padding: 6px 10px;
-  border: 1px solid rgba($color-black, 0.1);
-  color: rgba($color-black, 0.8);
+  border: 1px solid rgba(color-black, 0.1);
+  color: rgba(color-black, 0.8);
   color: var(--color-black-opacity-70);
   background: #fafafa;
 }

--- a/webapp/app/pods/components/conflict-item/styles.scss
+++ b/webapp/app/pods/components/conflict-item/styles.scss
@@ -1,22 +1,25 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-light-background, color-green, color-grey, color-error, color-success, color-black from 'accent-webapp/styles/variables/colors';
+
 & {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: background, border-color, transform;
   padding: 10px;
   margin-bottom: 15px;
 
   &:nth-child(even) {
-    background: $color-light-background;
+    background: color-light-background;
   }
 
   &:focus,
   &:hover {
-    border-color: lighten($color-green, 40%);
+    border-color: lighten(color-green, 40%);
     border-color: var(--color-primary-opacity-10);
-    background: $color-light-background;
+    background: color-light-background;
   }
 
   &.active {
-    background: $color-light-background;
+    background: color-light-background;
     transform: scale(1.02);
   }
 }
@@ -46,32 +49,32 @@
 &[class*='resolved'] {
   padding: 5px 10px;
   margin: 5px 0 15px;
-  background: lighten($color-green, 48%);
+  background: lighten(color-green, 48%);
   background: var(--color-primary-opacity-10);
-  box-shadow: 0 1px 5px lighten($color-grey, 25%);
+  box-shadow: 0 1px 5px lighten(color-grey, 25%);
 
   .item-key-prefix {
-    color: rgba($color-green, 0.7);
+    color: rgba(color-green, 0.7);
     color: var(--color-primary-opacity-70);
   }
 
   .item-key {
     font-size: 12px;
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }
 
 &[class*='errored'] {
   .textInput {
-    border-color: lighten($color-error, 30%);
+    border-color: lighten(color-error, 30%);
   }
 }
 
 .error {
   font-size: 12px;
   font-weight: bold;
-  color: $color-error;
+  color: color-error;
 }
 
 .item-key-prefix {
@@ -84,7 +87,7 @@
 .item-key {
   display: block;
   @extend %translationKeyBase;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   margin-right: 15px;
   line-height: 1.5;
@@ -121,36 +124,36 @@
 .conflictedText-textReference {
   padding: 8px 0;
   font-size: 13px;
-  color: darken($color-grey, 15%);
+  color: darken(color-grey, 15%);
 }
 
 .textDiff {
-  border-top: 1px dashed lighten($color-grey, 20%);
+  border-top: 1px dashed lighten(color-grey, 20%);
   white-space: pre-wrap;
 
   .added {
     padding: 0 3px;
-    background: lighten($color-success, 42%);
-    color: darken($color-success, 10%);
+    background: lighten(color-success, 42%);
+    color: darken(color-success, 10%);
   }
 
   .removed {
     padding: 0 3px;
-    background: lighten($color-error, 42%);
-    color: $color-error;
+    background: lighten(color-error, 42%);
+    color: color-error;
     text-decoration: line-through;
   }
 }
 
 .textConflicted {
   font-size: 11px;
-  color: lighten($color-grey, 5%);
+  color: lighten(color-grey, 5%);
 }
 
 .textConflicted-empty {
   font-size: 11px;
   font-style: italic;
-  color: lighten($color-grey, 10%);
+  color: lighten(color-grey, 10%);
 }
 
 .textConflicted-content {
@@ -159,14 +162,14 @@
 
 .conflictedText-textReference-link {
   margin-right: 4px;
-  color: rgba($color-black, 0.7);
+  color: rgba(color-black, 0.7);
   text-decoration: none;
   font-weight: normal;
   font-size: 12px;
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }
@@ -187,7 +190,7 @@
   font-size: 11px;
   font-style: italic;
   font-weight: normal;
-  color: lighten($color-grey, 10%);
+  color: lighten(color-grey, 10%);
 }
 
 .conflictedText-textReference-text-content {

--- a/webapp/app/pods/components/conflicts-filters/styles.scss
+++ b/webapp/app/pods/components/conflicts-filters/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black, color-grey from 'accent-webapp/styles/variables/colors';
+
 .subNavigation + & {
   position: relative;
   top: -1px;
@@ -31,26 +34,26 @@
 
 .input {
   @extend %textInput;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: border-color;
   width: 100%;
   padding: 7px 7px 7px 30px;
   font-family: $font-primary;
   font-size: 14px;
-  color: $color-black;
+  color: color-black;
 
   &:focus {
-    box-shadow: inset 0 1px 2px #f6f6f6, 0 1px 2px rgba($color-black, 0.06);
+    box-shadow: inset 0 1px 2px #f6f6f6, 0 1px 2px rgba(color-black, 0.06);
   }
 
   &::placeholder {
-    color: $color-grey;
+    color: color-grey;
   }
 }
 
 .totalEntries {
   margin-top: 10px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
 }
 

--- a/webapp/app/pods/components/dashboard-features-list/styles.scss
+++ b/webapp/app/pods/components/dashboard-features-list/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-green, color-grey, color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 0 15px 0 0;
   flex: 1 0 50%;
@@ -9,29 +12,29 @@
 
   &.item--highlight .item-link {
     padding: 10px 15px 12px;
-    background: lighten($color-green, 47%);
-    border-left: 2px solid $color-green;
+    background: lighten(color-green, 47%);
+    border-left: 2px solid color-green;
 
     .item-icon {
-      fill: $color-green;
+      fill: color-green;
     }
 
     .item-text {
-      color: darken($color-green, 25%);
+      color: darken(color-green, 25%);
     }
 
     .item-title {
-      color: $color-green;
+      color: color-green;
     }
 
     &:focus,
     &:hover {
       .item-title {
-        color: darken($color-green, 10%);
+        color: darken(color-green, 10%);
       }
 
       .item-text {
-        color: darken($color-green, 35%);
+        color: darken(color-green, 35%);
       }
     }
   }
@@ -39,32 +42,32 @@
 
 .item-link {
   display: block;
-  color: $color-grey;
+  color: color-grey;
   text-decoration: none;
 
   &:focus,
   &:hover {
     .item-title {
-      color: $color-green;
+      color: color-green;
     }
 
     .item-icon {
-      fill: $color-green;
+      fill: color-green;
     }
 
     .item-text {
-      color: darken($color-grey, 10%);
+      color: darken(color-grey, 10%);
     }
   }
 }
 
 .item-title {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   display: flex;
   align-items: center;
   padding-bottom: 5px;
-  color: $color-black;
+  color: color-black;
   font-size: 12px;
   font-weight: normal;
 }
@@ -74,20 +77,20 @@
 }
 
 .item-icon {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: fill;
   width: 18px;
   height: 18px;
   margin-right: 4px;
-  fill: $color-black;
+  fill: color-black;
 }
 
 .item-text {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   display: block;
   margin-top: 5px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
 }
 

--- a/webapp/app/pods/components/dashboard-revision-progress/styles.scss
+++ b/webapp/app/pods/components/dashboard-revision-progress/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-grey, color-error, color-warning, color-success, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   max-width: 330px;
   margin-bottom: 20px;
@@ -5,52 +8,52 @@
 
 &.master {
   .language-name {
-    color: darken($color-grey, 15%);
+    color: darken(color-grey, 15%);
   }
 }
 
 &.low-percentage {
   .reviewedStats {
-    color: $color-error;
+    color: color-error;
   }
 
   .container {
-    border-color: lighten($color-error, 47%);
-    background: lighten($color-error, 53%);
+    border-color: lighten(color-error, 47%);
+    background: lighten(color-error, 53%);
   }
 
   .progress {
-    background: $color-error;
+    background: color-error;
   }
 }
 
 &.medium-percentage {
   .reviewedStats {
-    color: $color-warning;
+    color: color-warning;
   }
 
   .container {
-    border-color: lighten($color-warning, 30%);
-    background: lighten($color-warning, 45%);
+    border-color: lighten(color-warning, 30%);
+    background: lighten(color-warning, 45%);
   }
 
   .progress {
-    background: $color-warning;
+    background: color-warning;
   }
 }
 
 &.high-percentage {
   .reviewedStats {
-    color: $color-success;
+    color: color-success;
   }
 
   .container {
-    border-color: lighten($color-success, 45%);
-    background: lighten($color-success, 53%);
+    border-color: lighten(color-success, 45%);
+    background: lighten(color-success, 53%);
   }
 
   .progress {
-    background: $color-success;
+    background: color-success;
   }
 }
 
@@ -58,20 +61,20 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .language-name {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
-  color: $color-grey;
+  color: color-grey;
   font-size: 14px;
   font-weight: bold;
   text-decoration: none;
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
   }
 }
 
@@ -79,7 +82,7 @@
   margin-left: 4px;
   font-weight: normal;
   font-size: 13px;
-  color: lighten($color-grey, 10%);
+  color: lighten(color-grey, 10%);
 }
 
 .reviewedStats {

--- a/webapp/app/pods/components/dashboard-revisions/item/styles.scss
+++ b/webapp/app/pods/components/dashboard-revisions/item/styles.scss
@@ -1,5 +1,8 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black, color-error, color-warning, color-success, color-grey, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: border-color;
   position: relative;
   flex: 1 1 calc(50% - 10px);
@@ -9,7 +12,7 @@
   margin-right: 10px;
   padding: 8px 15px 12px;
   border-radius: 3px;
-  box-shadow: 0 2px 4px rgba($color-black, 0.15);
+  box-shadow: 0 2px 4px rgba(color-black, 0.15);
 
   &:nth-child(even) {
     flex: 1 1 50%;
@@ -28,31 +31,31 @@
 
 &.low-percentage {
   .language-reviewedPercentage {
-    color: $color-error;
+    color: color-error;
   }
 
   .progress {
-    background: $color-error;
+    background: color-error;
   }
 }
 
 &.medium-percentage {
   .language-reviewedPercentage {
-    color: $color-warning;
+    color: color-warning;
   }
 
   .progress {
-    background: $color-warning;
+    background: color-warning;
   }
 }
 
 &.high-percentage {
   .language-reviewedPercentage {
-    color: $color-success;
+    color: color-success;
   }
 
   .progress {
-    background: $color-success;
+    background: color-success;
   }
 }
 
@@ -70,19 +73,19 @@
   align-items: flex-end;
   justify-content: space-between;
   margin-bottom: 6px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .language-name {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
-  color: darken($color-grey, 10%);
+  color: darken(color-grey, 10%);
   font-size: 12px;
   text-decoration: none;
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }
@@ -92,20 +95,20 @@
   margin-top: 5px;
   font-weight: normal;
   font-size: 25px;
-  color: lighten($color-grey, 10%);
+  color: lighten(color-grey, 10%);
 }
 
 .reviewedStats {
   padding: 2px 7px 1px;
   border-radius: 3px;
-  background: lighten($color-grey, 25%);
-  color: $color-grey;
+  background: lighten(color-grey, 25%);
+  color: color-grey;
   font-size: 12px;
   font-family: $font-monospace;
 }
 
 .actionsButton {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: opacity;
   position: absolute;
   right: 7px;
@@ -122,14 +125,14 @@
   &:focus,
   &:hover {
     .actionsButton-icon {
-      stroke: $color-green;
+      stroke: color-green;
       stroke: var(--color-primary);
     }
   }
 }
 
 .actionsButton-icon {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: stroke;
   width: 15px;
   height: 15px;
@@ -143,7 +146,7 @@
 .actionItem-text {
   margin-bottom: 7px;
   font-size: 12px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .actionItem-button {

--- a/webapp/app/pods/components/dashboard-revisions/styles.scss
+++ b/webapp/app/pods/components/dashboard-revisions/styles.scss
@@ -1,21 +1,23 @@
+@value color-error, color-warning, color-success, color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 &.low-percentage {
   .numberStat-reviewCompleted,
   .numberStat-reviewPercentage {
-    color: $color-error;
+    color: color-error;
   }
 }
 
 &.medium-percentage {
   .numberStat-reviewCompleted,
   .numberStat-reviewPercentage {
-    color: $color-warning;
+    color: color-warning;
   }
 }
 
 &.high-percentage {
   .numberStat-reviewCompleted,
   .numberStat-reviewPercentage {
-    color: $color-success;
+    color: color-success;
   }
 }
 
@@ -78,7 +80,7 @@
 
 .numberStat-reviewCompleted-successIcon {
   display: block;
-  stroke: rgba($color-success, 0.8);
+  stroke: rgba(color-success, 0.8);
   width: 52px;
   height: 52px;
   margin-bottom: 10px;
@@ -98,7 +100,7 @@
   padding-bottom: 5px;
   font-size: 14px;
   font-weight: bold;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 }
 
@@ -116,7 +118,7 @@
   background: #fff;
   box-shadow: 0 2px 6px rgba(#000, 0.09);
   border-radius: 2px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   text-decoration: none;
   transition: box-shadow 0.2s ease-in-out;
@@ -138,7 +140,7 @@
   width: 20px;
   height: 20px;
   margin-right: 5px;
-  fill: $color-green;
+  fill: color-green;
   fill: var(--color-primary);
 }
 
@@ -146,7 +148,7 @@
   display: block;
   margin-top: 10px;
   font-size: 11px;
-  color: rgba(darken($color-green, 20%), 0.5);
+  color: rgba(darken(color-green, 20%), 0.5);
   color: var(--color-black);
 }
 

--- a/webapp/app/pods/components/documents-add-button/styles.scss
+++ b/webapp/app/pods/components/documents-add-button/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-black from 'accent-webapp/styles/variables/colors';
+
 .button {
   display: inline-flex;
   align-items: center;
@@ -6,7 +8,7 @@
   background: #fff;
   box-shadow: 0 2px 4px rgba(#000, 0.09);
   border-radius: 3px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   font-weight: normal;
   font-size: 18px;
@@ -17,7 +19,7 @@
     background: var(--color-primary-opacity-10);
     border-color: darken(#fff, 4%);
     border-color: var(--color-primary-opacity-10);
-    color: $color-black;
+    color: color-black;
     color: var(--color-black);
   }
 }
@@ -26,6 +28,6 @@
   margin-right: 5px;
   width: 25px;
   height: 25px;
-  fill: $color-green;
+  fill: color-green;
   fill: var(--color-primary);
 }

--- a/webapp/app/pods/components/documents-list/item/styles.scss
+++ b/webapp/app/pods/components/documents-list/item/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-error, color-warning, color-success, color-grey, color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
   display: flex;
@@ -13,31 +16,31 @@
 
 &.low-percentage {
   .reviewedPercentage {
-    color: $color-error;
+    color: color-error;
   }
 
   .progress {
-    background: $color-error;
+    background: color-error;
   }
 }
 
 &.medium-percentage {
   .reviewedPercentage {
-    color: $color-warning;
+    color: color-warning;
   }
 
   .progress {
-    background: $color-warning;
+    background: color-warning;
   }
 }
 
 &.high-percentage {
   .reviewedPercentage {
-    color: $color-success;
+    color: color-success;
   }
 
   .progress {
-    background: $color-success;
+    background: color-success;
   }
 }
 
@@ -65,8 +68,8 @@
 .reviewedStats {
   padding: 2px 7px 1px;
   border-radius: 3px;
-  background: lighten($color-grey, 25%);
-  color: $color-grey;
+  background: lighten(color-grey, 25%);
+  color: color-grey;
   font-family: $font-monospace;
 }
 
@@ -106,14 +109,14 @@
 
 .item-document-deleting-title {
   display: flex;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
 }
 
 .item-document-deleting-title-loading {
   width: 10px;
   margin-right: 6px;
-  fill: $color-error;
+  fill: color-error;
 }
 
 .item-form {
@@ -169,7 +172,7 @@
 .item-document {
   margin-left: -20px;
   text-decoration: none;
-  color: $color-black;
+  color: color-black;
 }
 
 .item-edit-button {
@@ -186,7 +189,7 @@
   height: 16px;
   opacity: 0;
   stroke: #ccc;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: opacity, stroke;
 
   &:focus,

--- a/webapp/app/pods/components/dummy-login-form/styles.scss
+++ b/webapp/app/pods/components/dummy-login-form/styles.scss
@@ -1,10 +1,12 @@
+@value color-light-background, color-error, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   max-width: 500px;
   margin: 100px auto 30px;
   padding: 20px;
   box-shadow: 0 3px 21px rgba(#000, 0.07);
   border: 1px solid #eee;
-  background: $color-light-background;
+  background: color-light-background;
   text-align: center;
 }
 
@@ -18,10 +20,10 @@
   display: inline-block;
   padding: 10px 15px;
   margin-bottom: 20px;
-  background: lighten($color-error, 40%);
+  background: lighten(color-error, 40%);
   font-weight: bold;
   font-size: 12px;
-  color: $color-error;
+  color: color-error;
 }
 
 .subtitle {
@@ -46,7 +48,7 @@
 
   &:focus {
     border-right: 0;
-    border-color: $color-green;
+    border-color: color-green;
   }
 }
 

--- a/webapp/app/pods/components/empty-content/styles.scss
+++ b/webapp/app/pods/components/empty-content/styles.scss
@@ -1,3 +1,5 @@
+@value color-black, color-error, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   display: flex;
   justify-content: center;
@@ -5,14 +7,14 @@
   flex-direction: column;
   padding: 30px;
   margin: 0 auto;
-  color: rgba($color-black, 0.4);
+  color: rgba(color-black, 0.4);
   font-size: 18px;
   font-weight: 700;
   text-align: center;
 
   &.error {
     .icon {
-      stroke: $color-error;
+      stroke: color-error;
       opacity: 0.2;
       width: 100px;
       height: 100px;
@@ -20,7 +22,7 @@
   }
 
   &.success {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
 
     .icon {
@@ -39,7 +41,7 @@
 }
 
 .link {
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   text-decoration: none;
 

--- a/webapp/app/pods/components/error-section/styles.scss
+++ b/webapp/app/pods/components/error-section/styles.scss
@@ -1,10 +1,12 @@
+@value color-light-background, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   max-width: 400px;
   margin: 100px auto 30px;
   padding: 20px 20px 40px;
   box-shadow: 0 3px 21px rgba(#000, 0.07);
   border: 1px solid #eee;
-  background: $color-light-background;
+  background: color-light-background;
   text-align: center;
 }
 
@@ -24,11 +26,11 @@
 
 .status {
   margin-right: 15px;
-  text-shadow: 0 1px 2px rgba($color-green, 0.3);
+  text-shadow: 0 1px 2px rgba(color-green, 0.3);
   font-family: $font-monospace;
   font-size: 30px;
   font-weight: 300;
-  color: $color-green;
+  color: color-green;
 }
 
 .title {
@@ -36,7 +38,7 @@
   font-size: 14px;
   font-style: italic;
   font-weight: 300;
-  color: rgba($color-green, 0.7);
+  color: rgba(color-green, 0.7);
 }
 
 .text {
@@ -55,7 +57,7 @@
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     text-decoration: underline;
   }
 }

--- a/webapp/app/pods/components/jipt-back-to-translations/styles.scss
+++ b/webapp/app/pods/components/jipt-back-to-translations/styles.scss
@@ -1,18 +1,21 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black from 'accent-webapp/styles/variables/colors';
+
 .language {
   display: block;
   margin-bottom: 6px;
-  color: lighten($color-black, 20%);
+  color: lighten(color-black, 20%);
   font-size: 14px;
   text-decoration: none;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
 
   &:focus,
   &:hover {
-    color: $color-black;
+    color: color-black;
 
     .back-icon {
-      stroke: $color-black;
+      stroke: color-black;
       transform: translateX(-2px);
     }
   }
@@ -21,7 +24,7 @@
 .back-icon {
   width: 11px;
   height: 11px;
-  stroke: lighten($color-black, 20%);
-  transition: $transition-speed $transition-easing;
+  stroke: lighten(color-black, 20%);
+  transition: transition-speed transition-easing;
   transition-property: fill transform;
 }

--- a/webapp/app/pods/components/jipt-header/styles.scss
+++ b/webapp/app/pods/components/jipt-header/styles.scss
@@ -1,3 +1,5 @@
+@value color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   position: sticky;
   top: 0;
@@ -12,7 +14,7 @@
   margin: 0 0 0 10px;
   font-size: 14px;
   font-weight: 700;
-  color: $color-black;
+  color: color-black;
 }
 
 .applicationLogo {
@@ -25,7 +27,7 @@
   }
 
   path {
-    fill: $color-green;
+    fill: color-green;
     fill: var(--color-primary);
   }
 }

--- a/webapp/app/pods/components/jipt-translations-list/item/styles.scss
+++ b/webapp/app/pods/components/jipt-translations-list/item/styles.scss
@@ -1,12 +1,14 @@
+@value color-true-black, color-grey from 'accent-webapp/styles/variables/colors';
+
 .item-text {
   display: block;
   text-overflow: ellipsis;
   overflow-x: hidden;
-  color: $color-true-black;
+  color: color-true-black;
   font-size: 16px;
 
   &.item-text--empty {
-    color: $color-grey;
+    color: color-grey;
     font-style: italic;
   }
 }

--- a/webapp/app/pods/components/jipt-translations-list/styles.scss
+++ b/webapp/app/pods/components/jipt-translations-list/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-light-background, color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   margin: 20px 0;
   border-top: 1px solid #eee;
@@ -11,13 +14,13 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: padding, background;
 
   &:focus,
   &:hover {
-    background: $color-light-background;
-    color: $color-black;
+    background: color-light-background;
+    color: color-black;
     color: var(--color-black);
   }
 }

--- a/webapp/app/pods/components/loading-content/styles.scss
+++ b/webapp/app/pods/components/loading-content/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   display: flex;
   position: relative;
@@ -19,7 +21,7 @@ svg {
 
 circle {
   fill: none;
-  stroke: $color-grey;
+  stroke: color-grey;
   stroke-width: 2;
   stroke-dasharray: 1, 200;
   stroke-dashoffset: 0;
@@ -28,7 +30,7 @@ circle {
 }
 
 .label {
-  color: $color-grey;
+  color: color-grey;
   font-size: 14px;
   font-style: italic;
 }

--- a/webapp/app/pods/components/login-footer/styles.scss
+++ b/webapp/app/pods/components/login-footer/styles.scss
@@ -1,3 +1,5 @@
+@value color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   max-width: 500px;
   margin: 30px auto 60px;
@@ -7,11 +9,11 @@
 
 .text {
   font-size: 12px;
-  color: lighten($color-black, 50%);
+  color: lighten(color-black, 50%);
 }
 
 .link {
-  color: $color-green;
+  color: color-green;
   text-decoration: none;
 
   &:focus,

--- a/webapp/app/pods/components/login-forms/styles.scss
+++ b/webapp/app/pods/components/login-forms/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   max-width: 500px;
   margin: 0 auto 30px;
@@ -10,10 +12,10 @@
   width: 100%;
   font-family: $font-primary;
   font-size: 13px;
-  border: 2px solid darken($color-green, 5%);
+  border: 2px solid darken(color-green, 5%);
 
   &:focus {
-    border-color: $color-green;
+    border-color: color-green;
   }
 }
 
@@ -42,8 +44,8 @@
   }
 
   &.loginButton--dummy {
-    border: 2px solid darken($color-green, 5%);
-    background: $color-green;
+    border: 2px solid darken(color-green, 5%);
+    background: color-green;
     border-radius: 0 0 4px 4px;
     margin-top: -3px;
   }

--- a/webapp/app/pods/components/login-header/styles.scss
+++ b/webapp/app/pods/components/login-header/styles.scss
@@ -1,3 +1,5 @@
+@value color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   max-width: 500px;
   margin: 100px auto 40px;
@@ -14,13 +16,13 @@
   text-decoration: none;
   font-size: 25px;
   font-weight: 700;
-  color: $color-black;
+  color: color-black;
 }
 
 .text {
   font-size: 17px;
   line-height: 1.3;
-  color: lighten($color-black, 40%);
+  color: lighten(color-black, 40%);
 }
 
 .text-emphasis {
@@ -29,7 +31,7 @@
   font-weight: bold;
   font-size: 22px;
   font-style: normal;
-  color: $color-black;
+  color: color-black;
 }
 
 .logo {

--- a/webapp/app/pods/components/operations-peek/item/styles.scss
+++ b/webapp/app/pods/components/operations-peek/item/styles.scss
@@ -1,3 +1,5 @@
+@value color-border, color-grey, color-green, color-black, color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-bottom: 15px;
 }
@@ -15,8 +17,8 @@
 .languageHeader-displayOptions-button {
   padding: 0 10px;
   background: none;
-  border-right: 1px solid $color-border;
-  color: $color-grey;
+  border-right: 1px solid color-border;
+  color: color-grey;
   font-size: 13px;
 
   &:focus {
@@ -30,7 +32,7 @@
 }
 
 .languageHeader-displayOptions-button[disabled] {
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -38,7 +40,7 @@
 .operationsList {
   margin: 10px 0;
   background: #fff;
-  box-shadow: 0 2px 10px rgba($color-black, 0.06);
+  box-shadow: 0 2px 10px rgba(color-black, 0.06);
 }
 
 .stat {
@@ -69,7 +71,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 10px;
-  background: $color-light-background;
+  background: color-light-background;
 }
 
 .operation-content {
@@ -78,7 +80,7 @@
 
 .operation-action {
   font-size: 12px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .operation-key {
@@ -101,5 +103,5 @@
   padding: 20px 10px;
   font-style: italic;
   font-size: 12px;
-  color: $color-grey;
+  color: color-grey;
 }

--- a/webapp/app/pods/components/project-activities-filter/styles.scss
+++ b/webapp/app/pods/components/project-activities-filter/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey from 'accent-webapp/styles/variables/colors';
+
 .filterList {
   display: flex;
   align-items: center;
@@ -12,5 +14,5 @@
 }
 
 .label-text {
-  color: $color-grey;
+  color: color-grey;
 }

--- a/webapp/app/pods/components/project-activity/styles.scss
+++ b/webapp/app/pods/components/project-activity/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-light-background, color-error, color-green, color-black, color-success from 'accent-webapp/styles/variables/colors';
+
 .activity-title {
   font-size: 19px;
   color: #666;
@@ -14,7 +17,7 @@
   font-size: 14px;
   color: #555;
   padding: 10px 12px;
-  background: $color-light-background;
+  background: color-light-background;
   border-radius: 3px;
 }
 
@@ -42,11 +45,11 @@
 .rollbackButton {
   font-size: 13px;
   margin-left: 10px;
-  color: lighten($color-error, 25%);
+  color: lighten(color-error, 25%);
 
   &:focus,
   &:hover {
-    color: $color-error;
+    color: color-error;
   }
 
   .label {
@@ -73,7 +76,7 @@
   display: block;
   margin-bottom: 15px;
   font-size: 15px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -81,7 +84,7 @@
   max-height: 400px;
   overflow-y: scroll;
   border-radius: 3px;
-  box-shadow: inset 0 2px 5px rgba($color-black, 0.05);
+  box-shadow: inset 0 2px 5px rgba(color-black, 0.05);
   padding: 5px 7px;
   border: 1px solid #eee;
 }
@@ -104,7 +107,7 @@
   margin-right: 20px;
   padding: 13px;
   background: #fff;
-  box-shadow: 0 2px 10px rgba($color-black, 0.06);
+  box-shadow: 0 2px 10px rgba(color-black, 0.06);
   border-radius: 3px;
 }
 
@@ -143,12 +146,12 @@
   text-decoration: none;
   font-weight: 600;
   font-size: 12px;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }
@@ -188,7 +191,7 @@
   margin-left: 7px;
   font-size: 12px;
   font-style: italic;
-  color: $color-error;
+  color: color-error;
 }
 
 .translation-state-label {
@@ -204,13 +207,13 @@
   white-space: pre-wrap;
 
   .added {
-    background: lighten($color-success, 42%);
-    color: darken($color-success, 10%);
+    background: lighten(color-success, 42%);
+    color: darken(color-success, 10%);
   }
 
   .removed {
-    background: lighten($color-error, 48%);
-    color: $color-error;
+    background: lighten(color-error, 48%);
+    color: color-error;
     text-decoration: line-through;
   }
 }

--- a/webapp/app/pods/components/project-comments-list/item/styles.scss
+++ b/webapp/app/pods/components/project-comments-list/item/styles.scss
@@ -1,18 +1,21 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-light-background, color-green, color-black, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-bottom: 45px;
 }
 
 .translationCommentsList {
-  background: $color-light-background;
+  background: color-light-background;
   border-radius: 3px;
 }
 
 .item-link {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   @extend %translationKeyBase;
   display: inline-block;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   font-size: 12px;
   font-weight: bold;
@@ -20,7 +23,7 @@
 
   &:focus,
   &:hover {
-    color: darken($color-green, 15%);
+    color: darken(color-green, 15%);
     color: var(--color-primary-darken-10);
   }
 }
@@ -38,18 +41,18 @@
 }
 
 .item-language {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   display: block;
   font-size: 12px;
   text-decoration: none;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 }
 
 .item-badge {
   font-size: 12px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   text-decoration: none;
 }
@@ -58,5 +61,5 @@
   display: block;
   margin-top: 5px;
   font-size: 12px;
-  color: $color-error;
+  color: color-error;
 }

--- a/webapp/app/pods/components/project-create-form/styles.scss
+++ b/webapp/app/pods/components/project-create-form/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-error, color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 20px;
   background: #fff;
@@ -8,7 +10,7 @@
   text-align: center;
   font-size: 27px;
   font-weight: 300;
-  color: $color-green;
+  color: color-green;
 }
 
 .formItem-fields {
@@ -26,7 +28,7 @@
   font-family: $font-primary;
 
   &:focus {
-    border: 2px solid rgba($color-green, 0.7);
+    border: 2px solid rgba(color-green, 0.7);
   }
 }
 
@@ -61,12 +63,12 @@
 .errors {
   margin-bottom: 15px;
   padding-bottom: 5px;
-  border-bottom: 1px solid rgba($color-error, 0.3);
+  border-bottom: 1px solid rgba(color-error, 0.3);
 }
 
 .error {
   margin-bottom: 5px;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
   font-weight: bold;
 }
@@ -101,6 +103,6 @@
   min-height: 31px;
   border-color: #eee;
   border: 1px solid #eee;
-  background: $color-light-background;
+  background: color-light-background;
   box-shadow: 0 1px 5px rgba(#000, 0.06);
 }

--- a/webapp/app/pods/components/project-file-operation/styles.scss
+++ b/webapp/app/pods/components/project-file-operation/styles.scss
@@ -1,3 +1,5 @@
+@value color-error, color-green, color-light-background, color-grey, color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
   background: #fff;
@@ -13,7 +15,7 @@
   &:focus,
   &:hover {
     .closeButton-icon {
-      stroke: $color-error;
+      stroke: color-error;
     }
   }
 }
@@ -33,7 +35,7 @@
   align-items: center;
   font-size: 16px;
   font-weight: bold;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -41,7 +43,7 @@
   width: 18px;
   height: 18px;
   margin-right: 4px;
-  stroke: $color-green;
+  stroke: color-green;
   stroke: var(--color-primary);
 }
 
@@ -51,7 +53,7 @@
 }
 
 .versionTitle-name {
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -74,7 +76,7 @@
 .title {
   display: flex;
   padding: 12px 20px 12px 12px;
-  background: $color-light-background;
+  background: color-light-background;
   border-bottom: 1px solid #eee;
   font-size: 15px;
 }
@@ -88,7 +90,7 @@
 
 .title-documentExtension {
   font-size: 14px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .subtitle {
@@ -108,7 +110,7 @@
   margin-bottom: -20px;
   min-height: 50px;
   border-top: 0;
-  box-shadow: inset 0 2px 6px rgba($color-black, 0.05);
+  box-shadow: inset 0 2px 6px rgba(color-black, 0.05);
   background: #fff;
   overflow-x: scroll;
   font-family: $font-monospace;
@@ -140,7 +142,7 @@
 
 .sections-preview-title {
   font-size: 13px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .sections-preview-empty {
@@ -151,7 +153,7 @@
   text-align: center;
   font-size: 13px;
   font-style: italic;
-  color: $color-grey;
+  color: color-grey;
 }
 
 @media (max-width: (800px)) {

--- a/webapp/app/pods/components/project-navigation/list/styles.scss
+++ b/webapp/app/pods/components/project-navigation/list/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-grey, color-light-background, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   display: flex;
   flex-direction: column;
@@ -18,7 +21,7 @@
   align-items: center;
   position: relative;
   left: 1px;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color, background;
   padding: 8px 12px;
   margin-bottom: 10px;
@@ -26,11 +29,11 @@
   font-weight: 600;
   font-size: 13px;
   border-radius: 3px;
-  color: $color-grey;
+  color: color-grey;
 
   &:hover,
   &:focus {
-    background: $color-light-background;
+    background: color-light-background;
     color: var(--color-primary);
 
     .list-item-link-icon {
@@ -43,7 +46,7 @@
   }
 
   &.active {
-    background: lighten($color-green, 46%);
+    background: lighten(color-green, 46%);
     background: var(--color-primary);
     color: #fff;
 
@@ -60,13 +63,13 @@
 .list-item-link-text {
   width: 127px;
   padding: 0 0 0 12px;
-  color: $color-grey;
-  transition: $transition-speed $transition-easing;
+  color: color-grey;
+  transition: transition-speed transition-easing;
   transition-property: color;
 }
 
 .list-item-link-icon {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: fill;
   display: inline-block;
   width: 19px;

--- a/webapp/app/pods/components/project-navigation/styles.scss
+++ b/webapp/app/pods/components/project-navigation/styles.scss
@@ -1,3 +1,5 @@
+@value color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
   display: flex;
@@ -12,7 +14,7 @@
   font-size: 12px;
   font-weight: 700;
   text-decoration: none;
-  color: $color-black;
+  color: color-black;
   border-bottom: 1px solid #eee;
 }
 

--- a/webapp/app/pods/components/project-settings/api-token/styles.scss
+++ b/webapp/app/pods/components/project-settings/api-token/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 30px;
 }
@@ -26,18 +28,18 @@
 
   &:focus {
     outline: none;
-    border-color: lighten($color-green, 20%);
+    border-color: lighten(color-green, 20%);
     border-color: var(--color-primary-opacity-70);
-    box-shadow: 0 0 3px 2px rgba($color-green, 0.3);
+    box-shadow: 0 0 3px 2px rgba(color-green, 0.3);
     box-shadow: 0 0 3px 2px var(--color-primary-opacity-10);
 
     &::-moz-selection {
-      background: lighten($color-green, 45%);
+      background: lighten(color-green, 45%);
       background: var(--color-primary-opacity-10);
     }
 
     &::selection {
-      background: lighten($color-green, 45%);
+      background: lighten(color-green, 45%);
       background: var(--color-primary-opacity-10);
     }
   }

--- a/webapp/app/pods/components/project-settings/badges/styles.scss
+++ b/webapp/app/pods/components/project-settings/badges/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 30px;
 }
@@ -38,18 +40,18 @@
 
   &:focus {
     outline: none;
-    border-color: lighten($color-green, 20%);
+    border-color: lighten(color-green, 20%);
     border-color: var(--color-primary-opacity-70);
-    box-shadow: 0 0 3px 2px rgba($color-green, 0.3);
+    box-shadow: 0 0 3px 2px rgba(color-green, 0.3);
     box-shadow: 0 0 3px 2px var(--color-primary-opacity-10);
 
     &::-moz-selection {
-      background: lighten($color-green, 45%);
+      background: lighten(color-green, 45%);
       background: var(--color-primary-opacity-10);
     }
 
     &::selection {
-      background: lighten($color-green, 45%);
+      background: lighten(color-green, 45%);
       background: var(--color-primary-opacity-10);
     }
   }

--- a/webapp/app/pods/components/project-settings/collaborators/list/item/styles.scss
+++ b/webapp/app/pods/components/project-settings/collaborators/list/item/styles.scss
@@ -1,5 +1,8 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-grey, color-light-background, color-green, color-black from 'accent-webapp/styles/variables/colors';
+
 & {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: background;
   display: flex;
   justify-content: space-between;
@@ -11,7 +14,7 @@
 
   &.invited {
     .user {
-      color: $color-grey;
+      color: color-grey;
     }
   }
 
@@ -24,7 +27,7 @@
   &.editing,
   &:focus,
   &:hover {
-    background: $color-light-background;
+    background: color-light-background;
 
     .button {
       opacity: 1;
@@ -35,14 +38,14 @@
 .role {
   display: block;
   margin-bottom: 4px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   font-size: 12px;
 }
 
 .user {
   display: flex;
-  color: $color-black;
+  color: color-black;
   font-size: 15px;
 }
 
@@ -60,7 +63,7 @@
 }
 
 .invite {
-  color: $color-grey;
+  color: color-grey;
   font-size: 13px;
   font-style: italic;
 }
@@ -71,7 +74,7 @@
 
 .button {
   flex: 0 0 auto;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: opacity;
   opacity: 0;
   padding: 6px 7px;

--- a/webapp/app/pods/components/project-settings/collaborators/styles.scss
+++ b/webapp/app/pods/components/project-settings/collaborators/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
   margin-top: 30px;
@@ -10,7 +12,7 @@
   border-bottom: 1px solid #eee;
   padding-bottom: 6px;
   margin-bottom: 6px;
-  color: $color-grey;
+  color: color-grey;
   font-weight: bold;
   font-size: 17px;
 }
@@ -43,14 +45,14 @@
 
 .rolesList {
   padding: 5px 0 20px 20px;
-  border-left: 1px solid lighten($color-grey, 25%);
+  border-left: 1px solid lighten(color-grey, 25%);
 }
 
 .rolesList-title {
   display: block;
   padding-bottom: 5px;
   margin: 15px 0 0;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   font-weight: bold;
   font-size: 12px;
@@ -61,7 +63,7 @@
 }
 
 .rolesList-text {
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
 }
 

--- a/webapp/app/pods/components/project-settings/delete-form/styles.scss
+++ b/webapp/app/pods/components/project-settings/delete-form/styles.scss
@@ -1,3 +1,5 @@
+@value color-error, color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 90px;
 }
@@ -6,16 +8,16 @@
   display: block;
   width: 100%;
   padding-bottom: 6px;
-  border-bottom: 1px solid lighten($color-error, 48%);
+  border-bottom: 1px solid lighten(color-error, 48%);
   font-size: 19px;
-  color: darken($color-error, 10%);
+  color: darken(color-error, 10%);
 }
 
 .zone {
   margin-top: 12px;
   padding: 10px;
   border-radius: 3px;
-  background: $color-light-background;
+  background: color-light-background;
 }
 
 .zone-content {
@@ -26,11 +28,11 @@
 
 .zone-title {
   font-size: 13px;
-  color: darken($color-error, 26%);
+  color: darken(color-error, 26%);
 }
 
 .zone-text {
   font-size: 12px;
   font-style: italic;
-  color: rgba(darken($color-error, 30%), 0.5);
+  color: rgba(darken(color-error, 30%), 0.5);
 }

--- a/webapp/app/pods/components/project-settings/form/styles.scss
+++ b/webapp/app/pods/components/project-settings/form/styles.scss
@@ -1,3 +1,5 @@
+@value color-light-background, color-green, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 25px;
 }
@@ -31,7 +33,7 @@
   align-items: center;
   margin: 20px 0;
   padding: 10px;
-  background: $color-light-background;
+  background: color-light-background;
 }
 
 .lock-text-helper {
@@ -58,11 +60,11 @@
     border-color: #ddd;
 
     &:hover {
-      color: $color-green;
-      border-color: $color-green;
+      color: color-green;
+      border-color: color-green;
 
       .lock-icon {
-        stroke: $color-green;
+        stroke: color-green;
       }
     }
 
@@ -72,20 +74,20 @@
   }
 
   &.lock-text--active {
-    color: $color-error;
-    border-color: $color-error;
+    color: color-error;
+    border-color: color-error;
 
     &:hover {
-      color: darken($color-error, 10%);
-      border-color: darken($color-error, 10%);
+      color: darken(color-error, 10%);
+      border-color: darken(color-error, 10%);
 
       .lock-icon {
-        stroke: darken($color-error, 10%);
+        stroke: darken(color-error, 10%);
       }
     }
 
     .lock-icon {
-      stroke: $color-error;
+      stroke: color-error;
     }
   }
 }

--- a/webapp/app/pods/components/project-settings/integrations/styles.scss
+++ b/webapp/app/pods/components/project-settings/integrations/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
   margin-top: 30px;
@@ -10,7 +12,7 @@
   border-bottom: 1px solid #eee;
   padding-bottom: 6px;
   margin-bottom: 6px;
-  color: $color-grey;
+  color: color-grey;
   font-weight: bold;
   font-size: 17px;
 }

--- a/webapp/app/pods/components/project-settings/jipt/styles.scss
+++ b/webapp/app/pods/components/project-settings/jipt/styles.scss
@@ -1,3 +1,5 @@
+@value color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 30px;
 }
@@ -15,7 +17,7 @@
   padding-bottom: 10px;
   font-size: 16px;
   font-weight: 300;
-  color: $color-black;
+  color: color-black;
 }
 
 .code {
@@ -36,18 +38,18 @@
 
   &:focus {
     outline: none;
-    border-color: lighten($color-green, 20%);
+    border-color: lighten(color-green, 20%);
     border-color: var(--color-primary-opacity-70);
-    box-shadow: 0 0 3px 2px rgba($color-green, 0.3);
+    box-shadow: 0 0 3px 2px rgba(color-green, 0.3);
     box-shadow: 0 0 3px 2px var(--color-primary-opacity-10);
 
     &::-moz-selection {
-      background: lighten($color-green, 45%);
+      background: lighten(color-green, 45%);
       background: var(--color-primary-opacity-10);
     }
 
     &::selection {
-      background: lighten($color-green, 45%);
+      background: lighten(color-green, 45%);
       background: var(--color-primary-opacity-10);
     }
   }

--- a/webapp/app/pods/components/project-settings/links-list/styles.scss
+++ b/webapp/app/pods/components/project-settings/links-list/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-green, color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 10px;
 }
@@ -24,7 +27,7 @@
   text-decoration: none;
   font-weight: 600;
   font-size: 13px;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: background, border-color, color;
 
   .link-icon {
@@ -33,12 +36,12 @@
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
-    background: $color-light-background;
+    background: color-light-background;
 
     .link-icon {
-      stroke: $color-green;
+      stroke: color-green;
       stroke: var(--color-primary);
     }
   }
@@ -48,7 +51,7 @@
   width: 20px;
   height: 20px;
   margin-bottom: 3px;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: stroke;
 }
 

--- a/webapp/app/pods/components/project-settings/manage-languages/overview/styles.scss
+++ b/webapp/app/pods/components/project-settings/manage-languages/overview/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black, color-grey, color-green from 'accent-webapp/styles/variables/colors';
+
 .list {
   margin: 15px 0 0;
 }
@@ -5,7 +8,7 @@
 .list-item {
   margin-bottom: 5px;
   padding: 8px 2px;
-  border-bottom: 1px solid rgba($color-black, 0.1);
+  border-bottom: 1px solid rgba(color-black, 0.1);
   font-size: 14px;
 
   &.list-item--deleted {
@@ -22,7 +25,7 @@
   &.list-item--master {
     padding: 10px 2px;
     margin-bottom: 10px;
-    border-bottom-color: rgba($color-black, 0.2);
+    border-bottom-color: rgba(color-black, 0.2);
     font-size: 16px;
   }
 
@@ -49,7 +52,7 @@
   left: 0;
   top: 3px;
   padding-right: 12px;
-  color: $color-grey;
+  color: color-grey;
   opacity: 0;
   transform: translateX(-10px);
   transition: 0.2s ease-in-out;
@@ -57,7 +60,7 @@
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 
@@ -74,14 +77,14 @@
 
 .list-item-infos-date {
   font-size: 12px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .list-link {
   display: inline-flex;
   align-items: center;
   text-decoration: none;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 
   &:focus,
@@ -100,7 +103,7 @@
   display: flex;
   opacity: 0;
   pointer-events: none;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: opacity;
 }
 

--- a/webapp/app/pods/components/project-settings/manage-languages/styles.scss
+++ b/webapp/app/pods/components/project-settings/manage-languages/styles.scss
@@ -1,3 +1,5 @@
+@value color-black, color-light-background, color-grey, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   display: flex;
   margin-top: 25px;
@@ -17,7 +19,7 @@
   margin: 15px 0 5px;
   font-weight: 600;
   font-size: 13px;
-  color: $color-black;
+  color: color-black;
 
   &:first-of-type {
     margin-top: 0;
@@ -28,16 +30,16 @@
   display: block;
   max-width: 700px;
   font-size: 12px;
-  color: rgba($color-black, 0.8);
+  color: rgba(color-black, 0.8);
 }
 
 .emptyLanguages {
   font-size: 14px;
   padding: 10px;
-  background: $color-light-background;
+  background: color-light-background;
   border: 1px solid #eee;
   border-radius: 3px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .createSlaveForm {
@@ -48,14 +50,14 @@
   margin-bottom: 10px;
   font-size: 12px;
   font-weight: bold;
-  color: $color-error;
+  color: color-error;
 }
 
 .ember-power-select-trigger {
   min-height: 31px;
   max-width: 400px;
   margin-bottom: 20px;
-  background: $color-light-background;
+  background: color-light-background;
   border: 1px solid #eee;
 }
 

--- a/webapp/app/pods/components/project-settings/title/styles.scss
+++ b/webapp/app/pods/components/project-settings/title/styles.scss
@@ -1,5 +1,7 @@
+@value color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   font-size: 18px;
   font-weight: bold;
-  color: $color-black;
+  color: color-black;
 }

--- a/webapp/app/pods/components/projects-filters/styles.scss
+++ b/webapp/app/pods/components/projects-filters/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey, color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 .filters {
   margin: 0 auto;
   padding: 15px 15px 10px;
@@ -17,7 +19,7 @@
 
 .totalEntries {
   margin-left: 20px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 13px;
   font-style: italic;
 }
@@ -42,24 +44,24 @@
   padding: 7px 7px 7px 30px;
   font-size: 14px;
   font-family: $font-primary;
-  color: $color-black;
+  color: color-black;
 
   &::placeholder {
-    color: $color-grey;
+    color: color-grey;
   }
 
   &:focus {
-    border-color: $color-green;
+    border-color: color-green;
   }
 }
 
 .filters-meta {
   margin-top: 7px;
   font-size: 14px;
-  color: $color-grey;
+  color: color-grey;
 }
 
 .filters-meta-keyword {
   font-style: italic;
-  color: $color-green;
+  color: color-green;
 }

--- a/webapp/app/pods/components/projects-header/styles.scss
+++ b/webapp/app/pods/components/projects-header/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black, color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 64px 0 20px;
   background-image: linear-gradient(0, transparent, #eee);
@@ -9,7 +12,7 @@
   .applicationLogo {
     position: absolute;
     padding-right: 10px;
-    transition: $transition-speed $transition-easing;
+    transition: transition-speed transition-easing;
     transition-property: transform, opacity;
     transform: translate3d(0, 0, 0);
     opacity: 0;
@@ -59,7 +62,7 @@
 .applicationLogo-back,
 .applicationLogo-image {
   display: block;
-  transition: 0.7s $transition-easing;
+  transition: 0.7s transition-easing;
   transition-property: transform;
   width: 25px;
   height: 25px;
@@ -81,7 +84,7 @@
   text-decoration: none;
   font-size: 18px;
   font-weight: 700;
-  color: $color-black;
+  color: color-black;
 }
 
 .project {
@@ -91,7 +94,7 @@
   align-items: center;
   font-size: 18px;
   font-weight: 700;
-  color: $color-black;
+  color: color-black;
   text-decoration: none;
 }
 
@@ -141,17 +144,17 @@
 .search-input {
   padding: 10px 5px 10px 28px;
   border-radius: 50px;
-  border: 1px solid lighten($color-grey, 15%);
-  transition: 0.2s $transition-easing;
+  border: 1px solid lighten(color-grey, 15%);
+  transition: 0.2s transition-easing;
   transition-property: padding, border, box-shadow;
-  box-shadow: inset 0 1px 2px rgba($color-black, 0.1);
+  box-shadow: inset 0 1px 2px rgba(color-black, 0.1);
 
   &::placeholder {
-    color: lighten($color-grey, 5%);
+    color: lighten(color-grey, 5%);
   }
 
   &:hover {
-    border-color: $color-grey;
+    border-color: color-grey;
   }
 
   &:focus {

--- a/webapp/app/pods/components/projects-list/item/styles.scss
+++ b/webapp/app/pods/components/projects-list/item/styles.scss
@@ -1,44 +1,47 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-error, color-warning, color-success, color-black, color-light-background, color-grey from 'accent-webapp/styles/variables/colors';
+
 &.low-percentage {
   .language-reviewedPercentage {
-    color: $color-error;
+    color: color-error;
   }
 
   .progress {
-    background: $color-error;
+    background: color-error;
   }
 }
 
 &.medium-percentage {
   .language-reviewedPercentage {
-    color: $color-warning;
+    color: color-warning;
   }
 
   .progress {
-    background: $color-warning;
+    background: color-warning;
   }
 }
 
 &.high-percentage {
   .language-reviewedPercentage {
-    color: $color-success;
+    color: color-success;
   }
 
   .progress {
-    background: $color-success;
+    background: color-success;
   }
 }
 
 & {
   padding: 12px 15px;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: background;
   border-radius: 3px;
-  box-shadow: 0 2px 4px rgba($color-black, 0.15);
-  color: $color-black;
+  box-shadow: 0 2px 4px rgba(color-black, 0.15);
+  color: color-black;
 
   &:focus,
   &:hover {
-    background: $color-light-background;
+    background: color-light-background;
 
     .projectName {
       color: var(--color-primary);
@@ -53,7 +56,7 @@
 }
 
 .projectName {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   font-weight: 600;
   font-size: 18px;
@@ -74,7 +77,7 @@
 
 .projectUpdates {
   display: block;
-  color: $color-grey;
+  color: color-grey;
   font-style: italic;
   font-size: 11px;
 }
@@ -93,8 +96,8 @@
 .numberStat-totals {
   padding: 2px 7px 1px;
   border-radius: 3px;
-  background: lighten($color-grey, 25%);
-  color: $color-grey;
+  background: lighten(color-grey, 25%);
+  color: color-grey;
   font-size: 12px;
   font-family: $font-monospace;
 }

--- a/webapp/app/pods/components/related-translations-list/item/styles.scss
+++ b/webapp/app/pods/components/related-translations-list/item/styles.scss
@@ -1,9 +1,11 @@
+@value color-grey, color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
 
   &.empty {
     padding: 35px 10px;
-    color: $color-grey;
+    color: color-grey;
     font-size: 13px;
     font-style: italic;
     text-align: center;
@@ -18,21 +20,21 @@
   display: flex;
   align-items: center;
   margin-right: 4px;
-  color: rgba($color-black, 0.7);
+  color: rgba(color-black, 0.7);
   text-decoration: none;
   font-weight: normal;
   font-size: 12px;
 
   &:focus,
   &:hover {
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }
 
 .updatedAt {
   margin: 0 6px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 11px;
   font-style: italic;
 }
@@ -57,7 +59,7 @@
 
 .textEdit-cancel {
   margin-right: 20px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
   cursor: pointer;
 }

--- a/webapp/app/pods/components/related-translations-list/styles.scss
+++ b/webapp/app/pods/components/related-translations-list/styles.scss
@@ -1,10 +1,12 @@
+@value color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 30px;
 }
 
 .emptyItem {
   margin: 60px 0 15px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 13px;
   font-style: italic;
   text-align: center;

--- a/webapp/app/pods/components/removed-translation-edit/styles.scss
+++ b/webapp/app/pods/components/removed-translation-edit/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey from 'accent-webapp/styles/variables/colors';
+
 .text {
   width: 100%;
   min-height: 140px;
@@ -5,7 +7,7 @@
   padding: 15px;
   resize: vertical;
   outline: 0;
-  border: 1px solid lighten($color-grey, 20%);
+  border: 1px solid lighten(color-grey, 20%);
   background: darken(#fff, 2%);
   font-family: $font-monospace;
   font-size: 12px;
@@ -14,7 +16,7 @@
 .label {
   display: block;
   margin-top: 10px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 13px;
   font-style: italic;
   text-align: right;

--- a/webapp/app/pods/components/resource-pagination/styles.scss
+++ b/webapp/app/pods/components/resource-pagination/styles.scss
@@ -1,3 +1,5 @@
+@value color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   display: flex;
   align-items: center;
@@ -7,7 +9,7 @@
 
 .label {
   margin: 0 10px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 14px;
 }
 

--- a/webapp/app/pods/components/review-progress-bar/styles.scss
+++ b/webapp/app/pods/components/review-progress-bar/styles.scss
@@ -1,13 +1,15 @@
+@value color-black, color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   width: 100%;
   height: 2px;
   background: #eee;
   border-radius: 3px;
   overflow: hidden;
-  box-shadow: 0 1px 8px rgba($color-black, 0.04);
+  box-shadow: 0 1px 8px rgba(color-black, 0.04);
 }
 
 .progress {
   height: 5px;
-  background: $color-grey;
+  background: color-grey;
 }

--- a/webapp/app/pods/components/revision-selector/styles.scss
+++ b/webapp/app/pods/components/revision-selector/styles.scss
@@ -1,3 +1,5 @@
+@value color-light-background, color-black, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
   box-shadow: 0 2px 4px rgba(#000, 0.06);
@@ -14,7 +16,7 @@
     pointer-events: all;
 
     &:hover {
-      background: $color-light-background;
+      background: color-light-background;
     }
 
     .ember-power-select-status-icon {
@@ -38,14 +40,14 @@
 .ember-power-select-selected-item {
   margin-left: 10px;
   font-weight: 700;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 
   em {
     margin-left: 1px;
     font-size: 11px;
     font-style: normal;
-    color: $color-green;
+    color: color-green;
     color: var(--color-primary);
   }
 }

--- a/webapp/app/pods/components/revision-update-form/styles.scss
+++ b/webapp/app/pods/components/revision-update-form/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 20px;
   background: #fff;
@@ -8,7 +10,7 @@
   text-align: center;
   font-size: 27px;
   font-weight: 300;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -23,12 +25,12 @@
 .errors {
   margin-bottom: 15px;
   padding-bottom: 5px;
-  border-bottom: 1px solid rgba($color-error, 0.3);
+  border-bottom: 1px solid rgba(color-error, 0.3);
 }
 
 .error {
   margin-bottom: 5px;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
   font-weight: bold;
 }

--- a/webapp/app/pods/components/skeleton-ui/activities-list/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/activities-list/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-black, color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 20px;
 }
@@ -21,7 +23,7 @@
     }
 
     .item-icon {
-      background: rgba($color-green, 0.3);
+      background: rgba(color-green, 0.3);
       background: var(--color-primary-opacity-70);
     }
   }
@@ -53,7 +55,7 @@
   display: inline-block;
   height: 3px;
   width: 100px;
-  background: rgba($color-green, 0.5);
+  background: rgba(color-green, 0.5);
   background: var(--color-primary-opacity-70);
 }
 
@@ -62,7 +64,7 @@
   height: 4px;
   width: 90px;
   margin-right: 10px;
-  background: rgba($color-black, 0.2);
+  background: rgba(color-black, 0.2);
 }
 
 .item-text {
@@ -70,11 +72,11 @@
   height: 3px;
   width: 120px;
   margin-right: 10px;
-  background: rgba($color-black, 0.07);
+  background: rgba(color-black, 0.07);
 }
 
 .item-content {
   width: 100%;
   height: 30px;
-  background: $color-light-background;
+  background: color-light-background;
 }

--- a/webapp/app/pods/components/skeleton-ui/conflicts-items/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/conflicts-items/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-success from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 60px;
 }
@@ -21,7 +23,7 @@
   height: 5px;
   width: 120px;
   margin-bottom: 20px;
-  background: rgba($color-green, 0.1);
+  background: rgba(color-green, 0.1);
   background: var(--color-primary-opacity-10);
 }
 
@@ -47,7 +49,7 @@
   height: 3px;
   width: 250px;
   margin-bottom: 5px;
-  background: rgba($color-success, 0.1);
+  background: rgba(color-success, 0.1);
 }
 
 .item-textarea {

--- a/webapp/app/pods/components/skeleton-ui/documents-list/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/documents-list/styles.scss
@@ -1,3 +1,5 @@
+@value color-light-background, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 25px;
   display: flex;
@@ -27,7 +29,7 @@
   height: 3px;
   width: 160px;
   margin-bottom: 20px;
-  background: $color-light-background;
+  background: color-light-background;
 }
 
 .item-document {
@@ -46,6 +48,6 @@
 }
 
 .item-button--green {
-  border-color: rgba($color-green, 0.3);
-  background: rgba($color-green, 0.1);
+  border-color: rgba(color-green, 0.3);
+  background: rgba(color-green, 0.1);
 }

--- a/webapp/app/pods/components/skeleton-ui/progress-line/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/progress-line/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 &,
 &:before {
   height: 2px;
@@ -14,7 +16,7 @@
 }
 
 &:before {
-  background-color: lighten($color-green, 20%);
+  background-color: lighten(color-green, 20%);
   background-color: var(--color-primary-opacity-70);
   content: '';
   animation: progress-line-running-progress 1.8s cubic-bezier(0.5, 0, 0.1, 1)

--- a/webapp/app/pods/components/skeleton-ui/project-comments-list/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/project-comments-list/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 25px;
 }
@@ -27,7 +29,7 @@
   height: 5px;
   width: 180px;
   margin-bottom: 15px;
-  background: rgba($color-green, 0.3);
+  background: rgba(color-green, 0.3);
   background: var(--color-primary-opacity-70);
 }
 

--- a/webapp/app/pods/components/skeleton-ui/releases-list/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/releases-list/styles.scss
@@ -1,3 +1,5 @@
+@value color-light-background, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 25px;
 }
@@ -20,7 +22,7 @@
   height: 3px;
   width: 160px;
   margin-bottom: 20px;
-  background: $color-light-background;
+  background: color-light-background;
 }
 
 .item-document {
@@ -39,6 +41,6 @@
 }
 
 .item-button--green {
-  border-color: rgba($color-green, 0.3);
-  background: rgba($color-green, 0.1);
+  border-color: rgba(color-green, 0.3);
+  background: rgba(color-green, 0.1);
 }

--- a/webapp/app/pods/components/skeleton-ui/translation-splash-title/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/translation-splash-title/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin: 5px 0 62px;
 }
@@ -12,6 +14,6 @@
 .translation {
   height: 4px;
   width: 180px;
-  background: $color-green;
+  background: color-green;
   background: var(--color-primary);
 }

--- a/webapp/app/pods/components/skeleton-ui/versions-list/styles.scss
+++ b/webapp/app/pods/components/skeleton-ui/versions-list/styles.scss
@@ -1,3 +1,5 @@
+@value color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 25px;
 }
@@ -21,7 +23,7 @@
   height: 3px;
   width: 160px;
   margin-bottom: 20px;
-  background: $color-light-background;
+  background: color-light-background;
 }
 
 .item-document {

--- a/webapp/app/pods/components/translation-comment-form/styles.scss
+++ b/webapp/app/pods/components/translation-comment-form/styles.scss
@@ -1,3 +1,5 @@
+@value color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 30px;
 }
@@ -14,7 +16,7 @@
 .error {
   display: block;
   margin-bottom: 10px;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
   font-weight: bold;
 }

--- a/webapp/app/pods/components/translation-comments-list/styles.scss
+++ b/webapp/app/pods/components/translation-comments-list/styles.scss
@@ -1,8 +1,10 @@
+@value color-black, color-border, color-light-background, color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
   position: relative;
-  box-shadow: 0 1px 5px rgba($color-black, 0.04);
+  box-shadow: 0 1px 5px rgba(color-black, 0.04);
   border-radius: 3px;
-  border: 1px solid $color-border;
+  border: 1px solid color-border;
 }
 
 &.translationRemoved {
@@ -28,7 +30,7 @@
 
   &:focus,
   &:hover {
-    background: $color-light-background;
+    background: color-light-background;
   }
 
   &:last-of-type {
@@ -57,7 +59,7 @@
 }
 
 .itemComment-date {
-  color: darken($color-grey, 15%);
+  color: darken(color-grey, 15%);
   font-size: 11px;
 }
 

--- a/webapp/app/pods/components/translation-comments-subscriptions/item/styles.scss
+++ b/webapp/app/pods/components/translation-comments-subscriptions/item/styles.scss
@@ -1,3 +1,5 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+
 & {
   display: flex;
   align-items: flex-start;
@@ -5,7 +7,7 @@
   font-size: 13px;
   color: #888;
   cursor: pointer;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
 
   &:last-child {

--- a/webapp/app/pods/components/translation-comments-subscriptions/styles.scss
+++ b/webapp/app/pods/components/translation-comments-subscriptions/styles.scss
@@ -1,3 +1,5 @@
+@value color-black from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 5px 0 20px 20px;
   border-left: 1px solid #eee;
@@ -10,6 +12,6 @@
   font-size: 11px;
   font-weight: bold;
   font-style: normal;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 }

--- a/webapp/app/pods/components/translation-edit/form/styles.scss
+++ b/webapp/app/pods/components/translation-edit/form/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-blue, color-true-black, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   height: 100%;
 }
@@ -13,8 +15,8 @@
   color: #444;
 
   &.checked {
-    background: lighten($color-green, 45%);
-    color: darken($color-green, 25%);
+    background: lighten(color-green, 45%);
+    color: darken(color-green, 25%);
   }
 
   input {
@@ -25,9 +27,9 @@
 .label {
   width: 100%;
   padding: 5px 5px 5px 8px;
-  border-left: 2px solid lighten($color-blue, 40%);
+  border-left: 2px solid lighten(color-blue, 40%);
   margin-bottom: 5px;
-  background: lighten($color-blue, 46%);
+  background: lighten(color-blue, 46%);
   font-size: 12px;
   color: #888;
 }
@@ -55,19 +57,19 @@
   display: flex;
   align-items: center;
   padding: 10px 10px 0;
-  background: lighten($color-blue, 46%);
-  border-left: 2px solid lighten($color-blue, 40%);
+  background: lighten(color-blue, 46%);
+  border-left: 2px solid lighten(color-blue, 40%);
   font-size: 13px;
   font-weight: bold;
-  color: $color-blue;
+  color: color-blue;
 }
 
 .placeholders-text {
   margin-bottom: 6px;
   padding: 5px 10px 8px;
-  background: lighten($color-blue, 46%);
-  border-left: 2px solid lighten($color-blue, 40%);
-  color: darken($color-blue, 15%);
+  background: lighten(color-blue, 46%);
+  border-left: 2px solid lighten(color-blue, 40%);
+  color: darken(color-blue, 15%);
 }
 
 .placeholders-text-content {
@@ -78,13 +80,13 @@
   display: flex;
   align-items: center;
   padding-left: 12px;
-  border-left: 2px solid lighten($color-true-black, 80%);
+  border-left: 2px solid lighten(color-true-black, 80%);
   font-size: 14px;
-  color: darken($color-blue, 15%);
+  color: darken(color-blue, 15%);
 
   &.placeholders-item--warning {
-    border-color: lighten($color-error, 20%);
-    color: lighten($color-error, 10%);
+    border-color: lighten(color-error, 20%);
+    color: lighten(color-error, 10%);
   }
 }
 
@@ -92,12 +94,12 @@
   margin-right: 5px;
   width: 14px;
   height: 14px;
-  stroke: lighten($color-error, 15%);
+  stroke: lighten(color-error, 15%);
 }
 
 .placeholders-title-icon {
   width: 14px;
   height: 14px;
   margin-right: 6px;
-  stroke: darken($color-blue, 10%);
+  stroke: darken(color-blue, 10%);
 }

--- a/webapp/app/pods/components/translation-edit/lint-message/styles.scss
+++ b/webapp/app/pods/components/translation-edit/lint-message/styles.scss
@@ -1,22 +1,24 @@
+@value color-error, color-success from 'accent-webapp/styles/variables/colors';
+
 & {
   display: flex;
   align-items: center;
   padding: 2px 8px;
   margin-bottom: 5px;
   background: #fff;
-  border-left: 2px solid lighten($color-error, 10%);
+  border-left: 2px solid lighten(color-error, 10%);
   font-size: 12px;
 }
 
 .description {
-  color: lighten($color-error, 10%);
+  color: lighten(color-error, 10%);
 }
 
 .text {
   padding: 0 4px;
   margin-left: 5px;
-  color: $color-error;
-  background: lighten($color-error, 38%);
+  color: color-error;
+  background: lighten(color-error, 38%);
   font-weight: bold;
 }
 
@@ -40,8 +42,8 @@
 .single-replacement {
   margin-left: 4px;
   padding: 0 4px;
-  background: lighten($color-success, 38%);
-  color: $color-success;
+  background: lighten(color-success, 38%);
+  color: color-success;
   font-size: 12px;
   font-weight: bold;
 }

--- a/webapp/app/pods/components/translation-edit/styles.scss
+++ b/webapp/app/pods/components/translation-edit/styles.scss
@@ -1,15 +1,18 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-grey, color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-top: 30px;
 }
 
 .previousText {
   margin-bottom: 15px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
 }
 
 .previousText-label {
-  color: darken($color-grey, 10%);
+  color: darken(color-grey, 10%);
   font-weight: bold;
 }
 
@@ -36,9 +39,9 @@
   font-size: 13px;
   font-weight: bold;
   text-decoration: none;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color, opacity;
 
   &:focus,
@@ -51,9 +54,9 @@
   width: 18px;
   height: 18px;
   margin-right: 3px;
-  stroke: $color-green;
+  stroke: color-green;
   stroke: var(--color-primary);
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: stroke;
 }
 
@@ -69,7 +72,7 @@
 
 .actions-updatedAt {
   margin-right: 10px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 11px;
   font-style: italic;
 }

--- a/webapp/app/pods/components/translation-splash-title/styles.scss
+++ b/webapp/app/pods/components/translation-splash-title/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black, color-green, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   margin-bottom: 40px;
 }
@@ -5,11 +8,11 @@
 .language {
   display: block;
   margin-bottom: 6px;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
   font-size: 14px;
   text-decoration: none;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
 
   &:focus,
@@ -25,9 +28,9 @@
 .back-icon {
   width: 11px;
   height: 11px;
-  stroke: $color-black;
+  stroke: color-black;
   stroke: var(--color-black);
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: stroke transform;
 }
 
@@ -36,7 +39,7 @@
   margin-bottom: 3px;
   font-weight: bold;
   font-size: 22px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   line-height: 1.3;
 }
@@ -62,15 +65,15 @@
   display: block;
   margin-top: 10px;
   font-size: 12px;
-  color: $color-error;
+  color: color-error;
 }
 
 .conflictedBadge {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: border-color, color, background;
   display: inline-block;
   padding: 1px 6px 1px 5px;
-  background: $color-green;
+  background: color-green;
   border-radius: 3px;
   color: #fff;
   font-size: 11px;
@@ -80,8 +83,8 @@
 
   &:focus,
   &:hover {
-    color: darken($color-green, 10%);
-    background: lighten($color-green, 38%);
-    border-color: lighten($color-green, 20%);
+    color: darken(color-green, 10%);
+    background: lighten(color-green, 38%);
+    border-color: lighten(color-green, 20%);
   }
 }

--- a/webapp/app/pods/components/translations-filter/styles.scss
+++ b/webapp/app/pods/components/translations-filter/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-black, color-grey, color-green from 'accent-webapp/styles/variables/colors';
+
 .subNavigation + & {
   position: relative;
   top: -1px;
@@ -35,14 +38,14 @@
   padding: 7px 7px 7px 30px;
   font-family: $font-primary;
   font-size: 14px;
-  color: $color-black;
+  color: color-black;
 
   &:focus {
-    box-shadow: inset 0 1px 2px #f6f6f6, 0 1px 2px rgba($color-black, 0.06);
+    box-shadow: inset 0 1px 2px #f6f6f6, 0 1px 2px rgba(color-black, 0.06);
   }
 
   &::placeholder {
-    color: $color-grey;
+    color: color-grey;
   }
 }
 
@@ -52,8 +55,8 @@
   border-radius: 3px;
   background: #fff;
   border: 1px solid #eee;
-  box-shadow: 0 1px 4px rgba($color-black, 0.05);
-  transition: $transition-speed $transition-easing;
+  box-shadow: 0 1px 4px rgba(color-black, 0.05);
+  transition: transition-speed transition-easing;
   transition-property: background;
 
   &:focus {
@@ -76,7 +79,7 @@
   position: absolute;
   top: -10px;
   right: -12px;
-  background: $color-green;
+  background: color-green;
   background: var(--color-primary);
   border-radius: 2px;
   padding: 0 4px 1px;
@@ -94,7 +97,7 @@
 .totalEntries {
   flex-shrink: 0;
   margin-top: 10px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
 }
 

--- a/webapp/app/pods/components/translations-list/item/styles.scss
+++ b/webapp/app/pods/components/translations-list/item/styles.scss
@@ -1,5 +1,8 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-light-background, color-error, color-green, color-grey from 'accent-webapp/styles/variables/colors';
+
 & {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: background, transform;
   display: block;
   margin: 8px 0;
@@ -9,7 +12,7 @@
 
   &:focus,
   &:hover {
-    background: $color-light-background;
+    background: color-light-background;
 
     .item-edit {
       transform: translateX(-50px);
@@ -18,7 +21,7 @@
   }
 
   &.item--editMode {
-    background: $color-light-background;
+    background: color-light-background;
     transform: scale(1.02);
 
     .item-edit {
@@ -29,7 +32,7 @@
     .item-edit-icon {
       &:focus,
       &:hover {
-        stroke: $color-error;
+        stroke: color-error;
       }
     }
   }
@@ -41,7 +44,7 @@
   &:focus,
   &:hover {
     .item-key {
-      color: $color-green;
+      color: color-green;
       color: var(--color-primary);
     }
   }
@@ -70,13 +73,13 @@
   width: 18px;
   height: 18px;
   cursor: pointer;
-  stroke: $color-grey;
-  transition: $transition-speed $transition-easing;
+  stroke: color-grey;
+  transition: transition-speed transition-easing;
   transition-property: stroke;
 
   &:focus,
   &:hover {
-    stroke: $color-green;
+    stroke: color-green;
     stroke: var(--color-primary);
   }
 }
@@ -91,7 +94,7 @@
 .item-key {
   display: block;
   @extend %translationKeyBase;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color;
   margin-right: 15px;
   line-height: 1.5;
@@ -110,7 +113,7 @@
   border-radius: 3px;
   padding: 6px 10px;
   cursor: text;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: border-color, color;
 
   &.item-text--empty {
@@ -128,7 +131,7 @@
 
 .item-updatedAt {
   margin-left: 5px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 11px;
 }
 
@@ -139,7 +142,7 @@
 
 .item-textEdit-cancel {
   margin-right: 20px;
-  color: $color-grey;
+  color: color-grey;
   font-size: 12px;
   cursor: pointer;
 }

--- a/webapp/app/pods/components/version-create-form/styles.scss
+++ b/webapp/app/pods/components/version-create-form/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 20px;
   background: #fff;
@@ -8,7 +10,7 @@
   text-align: center;
   font-size: 27px;
   font-weight: 300;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -33,12 +35,12 @@
 .errors {
   margin-bottom: 15px;
   padding-bottom: 5px;
-  border-bottom: 1px solid rgba($color-error, 0.3);
+  border-bottom: 1px solid rgba(color-error, 0.3);
 }
 
 .error {
   margin-bottom: 5px;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
   font-weight: bold;
 }

--- a/webapp/app/pods/components/version-update-form/styles.scss
+++ b/webapp/app/pods/components/version-update-form/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-error from 'accent-webapp/styles/variables/colors';
+
 & {
   padding: 20px;
   background: #fff;
@@ -8,7 +10,7 @@
   text-align: center;
   font-size: 27px;
   font-weight: 300;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
@@ -33,12 +35,12 @@
 .errors {
   margin-bottom: 15px;
   padding-bottom: 5px;
-  border-bottom: 1px solid rgba($color-error, 0.3);
+  border-bottom: 1px solid rgba(color-error, 0.3);
 }
 
 .error {
   margin-bottom: 5px;
-  color: $color-error;
+  color: color-error;
   font-size: 13px;
   font-weight: bold;
 }

--- a/webapp/app/pods/components/versions-add-button/styles.scss
+++ b/webapp/app/pods/components/versions-add-button/styles.scss
@@ -1,3 +1,5 @@
+@value color-green, color-black from 'accent-webapp/styles/variables/colors';
+
 .button {
   display: inline-flex;
   align-items: center;
@@ -5,7 +7,7 @@
   background: #fff;
   box-shadow: 0 2px 4px rgba(#000, 0.09);
   border-radius: 3px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   font-weight: normal;
   font-size: 18px;
@@ -16,7 +18,7 @@
     background: var(--color-primary-opacity-10);
     border-color: darken(#fff, 4%);
     border-color: var(--color-primary-opacity-10);
-    color: $color-black;
+    color: color-black;
     color: var(--color-black);
   }
 }
@@ -25,6 +27,6 @@
   margin-right: 5px;
   width: 25px;
   height: 25px;
-  fill: $color-green;
+  fill: color-green;
   fill: var(--color-primary);
 }

--- a/webapp/app/pods/components/versions-list/styles.scss
+++ b/webapp/app/pods/components/versions-list/styles.scss
@@ -1,3 +1,5 @@
+@value color-green from 'accent-webapp/styles/variables/colors';
+
 & {
   width: 100%;
 }
@@ -20,13 +22,13 @@
   display: flex;
   align-items: center;
   font-size: 23px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
 .item-title-link {
   text-decoration: none;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 
   &:hover {

--- a/webapp/app/pods/components/welcome-project/styles.scss
+++ b/webapp/app/pods/components/welcome-project/styles.scss
@@ -1,3 +1,6 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+@value color-green, color-grey, color-black, color-light-background from 'accent-webapp/styles/variables/colors';
+
 & {
   width: 100%;
   margin: 0 30px;
@@ -14,13 +17,13 @@
   margin-bottom: 15px;
   line-height: 1;
   font-size: 48px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
 }
 
 .heroTitle-text {
   font-size: 18px;
-  color: lighten($color-grey, 10%);
+  color: lighten(color-grey, 10%);
 }
 
 .subtitle {
@@ -28,7 +31,7 @@
   margin: 20px 0 10px;
   font-weight: bold;
   font-size: 16px;
-  color: $color-black;
+  color: color-black;
   color: var(--color-black);
 }
 
@@ -52,24 +55,24 @@
   padding: 20px;
   margin-bottom: 10px;
   margin-right: 10px;
-  box-shadow: 0 2px 4px rgba($color-black, 0.15);
+  box-shadow: 0 2px 4px rgba(color-black, 0.15);
   border-radius: 4px;
-  color: $color-green;
+  color: color-green;
   color: var(--color-primary);
   text-decoration: none;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: background;
 
   &:focus,
   &:hover {
-    background: $color-light-background;
+    background: color-light-background;
   }
 }
 
 .link-subtitle {
   display: block;
   font-size: 12px;
-  color: rgba($color-grey, 0.8);
+  color: rgba(color-grey, 0.8);
 }
 
 .link-icon {
@@ -81,6 +84,6 @@
 }
 
 .link-icon {
-  stroke: $color-green;
+  stroke: color-green;
   stroke: var(--color-primary);
 }

--- a/webapp/app/styles/app.scss
+++ b/webapp/app/styles/app.scss
@@ -20,8 +20,6 @@
 @import 'html-components/form/button';
 @import 'html-components/form/label';
 
-@import 'pod-styles';
-
 div.emoji-picker {
   z-index: 3001;
   border: 0;

--- a/webapp/app/styles/classes.scss
+++ b/webapp/app/styles/classes.scss
@@ -1,3 +1,5 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+
 %centeredWrapper {
   margin: 0 auto;
   max-width: $screen-lg;
@@ -26,7 +28,7 @@
 }
 
 %textInput {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: border box-shadow;
   resize: vertical;
   outline: 0;

--- a/webapp/app/styles/html-components/form/button.scss
+++ b/webapp/app/styles/html-components/form/button.scss
@@ -1,7 +1,9 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+
 .button {
   display: inline-flex;
   align-items: center;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: all;
   appearance: none;
   margin: 0;
@@ -23,7 +25,7 @@
 .button-icon {
   position: relative;
   top: 3px;
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: fill;
   width: 14px;
   height: 14px;

--- a/webapp/app/styles/html-components/sub-navigation.scss
+++ b/webapp/app/styles/html-components/sub-navigation.scss
@@ -1,3 +1,5 @@
+@value transition-speed, transition-easing from 'accent-webapp/styles/variables/transitions';
+
 .subNavigation {
   border-radius: 3px;
   overflow: hidden;
@@ -38,7 +40,7 @@
 }
 
 .subNavigation-list-item-link {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: color, border-color, background;
   display: flex;
   align-items: center;
@@ -73,7 +75,7 @@
 }
 
 .subNavigation-list-item-link-icon {
-  transition: $transition-speed $transition-easing;
+  transition: transition-speed transition-easing;
   transition-property: stroke;
   width: 20px;
   height: 20px;

--- a/webapp/app/styles/variables/colors.scss
+++ b/webapp/app/styles/variables/colors.scss
@@ -1,14 +1,14 @@
-$color-green: #28cb87;
-$color-blue: #3f7cc5;
-$color-border: #e0e0e0;
+@value color-green: #28cb87;
+@value color-blue: #3f7cc5;
+@value color-border: #e0e0e0;
 
-$color-true-black: #1a211d;
-$color-black: #3a3a3a;
+@value color-true-black: #1a211d;
+@value color-black: #3a3a3a;
 
-$color-grey: #adadad;
-$color-light-background: #fafafa;
+@value color-grey: #adadad;
+@value color-light-background: #fafafa;
 
-$color-success: #45c86f;
-$color-warning: #e4b600;
-$color-socket: #2c4fb4;
-$color-error: #d84444;
+@value color-success: #45c86f;
+@value color-warning: #e4b600;
+@value color-socket: #2c4fb4;
+@value color-error: #d84444;

--- a/webapp/app/styles/variables/dimensions.scss
+++ b/webapp/app/styles/variables/dimensions.scss
@@ -1,5 +1,5 @@
-$screen-lg: 1300px;
-$screen-md: 640px;
-$screen-sm: 440px;
+@value screen-lg: 1300px;
+@value screen-md: 640px;
+@value screen-sm: 440px;
 
-$border-radius: 3px;
+@value border-radius: 3px;

--- a/webapp/app/styles/variables/transitions.scss
+++ b/webapp/app/styles/variables/transitions.scss
@@ -1,2 +1,2 @@
-$transition-speed: 250ms;
-$transition-easing: ease;
+@value transition-speed: 250ms;
+@value transition-easing: ease;


### PR DESCRIPTION
In an effort to migrate all the components to Glimmer, we need to go from `ember-component-css` to `ember-css-modules` since `ember-component-css` doesn’t work with Glimmer (and kinda looks dead…)

In short, now the styles are built differently and we must use `@value` to use variables.