### PR TITLE
Collaborator's email must be unique for a projet

### DIFF
--- a/lib/accent/schemas/collaborator.ex
+++ b/lib/accent/schemas/collaborator.ex
@@ -22,9 +22,11 @@ defmodule Accent.Collaborator do
     model
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> update_change(:email, &String.trim/1)
     |> validate_format(:email, ~r/.+@.+/)
-    |> downcase_email(params)
+    |> update_change(:email, &String.downcase/1)
     |> validate_inclusion(:role, @possible_roles)
+    |> unique_constraint(:email, name: :collaborators_email_project_id_index)
   end
 
   def update_changeset(model, params) do
@@ -32,10 +34,4 @@ defmodule Accent.Collaborator do
     |> cast(params, [:role])
     |> validate_inclusion(:role, @possible_roles)
   end
-
-  defp downcase_email(changeset, %{"email" => email}) do
-    put_change(changeset, :email, String.downcase(email))
-  end
-
-  defp downcase_email(changeset, _params), do: changeset
 end

--- a/priv/repo/migrations/20200430174230_unique_collaborator_email.exs
+++ b/priv/repo/migrations/20200430174230_unique_collaborator_email.exs
@@ -13,7 +13,7 @@ defmodule Accent.Repo.Migrations.UniqueCollaboratorEmail do
       WHERE inserted_at > (
        SELECT oldest_email_collaborators.inserted_at
        FROM oldest_email_collaborators
-       WHERE collaborators.email  = oldest_email_collaborators.email
+       WHERE collaborators.email = oldest_email_collaborators.email
       )
       """,
       ""

--- a/priv/repo/migrations/20200430174230_unique_collaborator_email.exs
+++ b/priv/repo/migrations/20200430174230_unique_collaborator_email.exs
@@ -1,0 +1,24 @@
+defmodule Accent.Repo.Migrations.UniqueCollaboratorEmail do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      """
+      WITH oldest_email_collaborators AS (
+       SELECT email, MIN(inserted_at) as inserted_at
+       FROM collaborators
+       GROUP BY email
+      )
+      DELETE FROM collaborators
+      WHERE inserted_at > (
+       SELECT oldest_email_collaborators.inserted_at
+       FROM oldest_email_collaborators
+       WHERE collaborators.email  = oldest_email_collaborators.email
+      )
+      """,
+      ""
+    )
+
+    create(unique_index(:collaborators, [:email, :project_id]))
+  end
+end

--- a/test/services/collaborator_creator_test.exs
+++ b/test/services/collaborator_creator_test.exs
@@ -1,7 +1,7 @@
 defmodule AccentTest.CollaboratorCreator do
   use Accent.RepoCase
 
-  alias Accent.{CollaboratorCreator, Project, Repo, User}
+  alias Accent.{Collaborator, CollaboratorCreator, Project, Repo, User}
 
   test "create unknown email" do
     email = "test@test.com"
@@ -51,5 +51,35 @@ defmodule AccentTest.CollaboratorCreator do
     {:ok, collaborator} = CollaboratorCreator.create(%{"email" => email, "assigner_id" => assigner.id, "role" => role, "project_id" => project.id})
 
     assert collaborator.email === "test@test.com"
+  end
+
+  test "create with leading and trailing spaces in email" do
+    email = "    test@test.com   "
+    project = %Project{main_color: "#f00", name: "com"} |> Repo.insert!()
+    assigner = %User{email: "lol@test.com"} |> Repo.insert!()
+    role = "admin"
+
+    {:ok, collaborator} = CollaboratorCreator.create(%{"email" => email, "assigner_id" => assigner.id, "role" => role, "project_id" => project.id})
+
+    assert collaborator.email === "test@test.com"
+  end
+
+  test "cannot create with already used email for project" do
+    email = "test@test.com"
+    project = %Project{main_color: "#f00", name: "com"} |> Repo.insert!()
+    assigner = %User{email: "lol@test.com"} |> Repo.insert!()
+    role = "admin"
+    %Collaborator{email: email, assigner_id: assigner.id, role: role, project_id: project.id} |> Repo.insert!()
+
+    {:error, changeset} = CollaboratorCreator.create(%{"email" => email, "assigner_id" => assigner.id, "role" => role, "project_id" => project.id})
+
+    assert changeset.errors === [
+             email:
+               {"has already been taken",
+                [
+                  constraint: :unique,
+                  constraint_name: "collaborators_email_project_id_index"
+                ]}
+           ]
   end
 end


### PR DESCRIPTION
### Bug description
When adding a collaborator to a projet, we were able to invite the same email.

### Solution
* Add a database constraint for table `collaborators` creating a unique index with `[:email, :project_id]`
* As maybe some collaborators were duplicated we need to keep only one of them to be able to create the unique constraint. We decided to keep only the oldest created collaborator for duplicated ones.
* We check this database constraint in create changeset.

### Notes
* Not related to this issue, but we remove the leading and trailing spaces before saving email
* use `update_change(changeset, :email, &String.downcase/1)` instead of calling a private function

### Result
![Capture d’écran, le 2020-04-30 à 17 38 22](https://user-images.githubusercontent.com/24735615/80762462-98571880-8b0a-11ea-8f4e-236585df47fc.png)

![Capture d’écran, le 2020-04-30 à 17 38 42](https://user-images.githubusercontent.com/24735615/80762471-9d1bcc80-8b0a-11ea-8f2b-d4037202197d.png)


