### PR TITLE
Add version requirement filter fallback for version tag param

### DIFF
--- a/lib/accent/schemas/version.ex
+++ b/lib/accent/schemas/version.ex
@@ -4,6 +4,7 @@ defmodule Accent.Version do
   schema "versions" do
     field(:name, :string)
     field(:tag, :string)
+    field(:parsed_tag, :any, virtual: true)
 
     belongs_to(:user, Accent.User)
     belongs_to(:project, Accent.Project)
@@ -21,5 +22,14 @@ defmodule Accent.Version do
     |> cast(params, @required_fields)
     |> validate_required(@required_fields)
     |> unique_constraint(:tag, name: :versions_tag_project_id_index)
+  end
+
+  def with_parsed_tag(version) do
+    trimmed_tag = String.trim_leading(version.tag, "v")
+
+    case Version.parse(trimmed_tag) do
+      {:ok, tag} -> %{version | parsed_tag: tag}
+      _ -> %{version | parsed_tag: :error}
+    end
   end
 end

--- a/lib/accent/schemas/version.ex
+++ b/lib/accent/schemas/version.ex
@@ -25,9 +25,10 @@ defmodule Accent.Version do
   end
 
   def with_parsed_tag(version) do
-    trimmed_tag = String.trim_leading(version.tag, "v")
-
-    case Version.parse(trimmed_tag) do
+    version.tag
+    |> String.trim_leading("v")
+    |> Version.parse()
+    |> case do
       {:ok, tag} -> %{version | parsed_tag: tag}
       _ -> %{version | parsed_tag: :error}
     end

--- a/lib/web/plugs/movement_context_parser.ex
+++ b/lib/web/plugs/movement_context_parser.ex
@@ -40,8 +40,8 @@ defmodule Accent.Plugs.MovementContextParser do
 
   def assign_version(conn = %{assigns: %{project: project}, params: %{"version" => version}}, _) do
     Version
-    |> VersionScope.from_tag(version)
     |> VersionScope.from_project(project.id)
+    |> VersionScope.from_tag(version)
     |> Repo.one()
     |> case do
       nil ->

--- a/test/scopes/version_test.exs
+++ b/test/scopes/version_test.exs
@@ -1,4 +1,92 @@
 defmodule AccentTest.Scopes.Version do
-  use ExUnit.Case, async: true
+  use Accent.RepoCase, async: true
   doctest Accent.Scopes.Version
+
+  alias Accent.{
+    Project,
+    Repo,
+    User,
+    Version
+  }
+
+  alias Accent.Scopes.Version, as: VersionScope
+
+  defp assert_match_version(versions, version) do
+    assert length(versions) === 1
+    assert Enum.at(versions, 0).id === version.id
+  end
+
+  defp insert_version(tag, project, user) do
+    %Version{name: "foo", tag: tag, project_id: project.id, user_id: user.id} |> Repo.insert!()
+  end
+
+  setup do
+    user = Repo.insert!(%User{email: "test@test.com"})
+    project = %Project{main_color: "#f00", name: "My project"} |> Repo.insert!()
+
+    {:ok, [user: user, project: project]}
+  end
+
+  test "filter no match tag", %{project: project, user: user} do
+    insert_version("v1", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, "== 1.1.0"))
+
+    assert versions === []
+  end
+
+  test "filter exact tag", %{project: project, user: user} do
+    version = insert_version("v1", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, version.tag))
+
+    assert_match_version(versions, version)
+  end
+
+  test "filter requirement tag", %{project: project, user: user} do
+    version = insert_version("1.1.2", project, user)
+    insert_version("1.2.2", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, "== 1.1.2"))
+
+    assert_match_version(versions, version)
+  end
+
+  test "filter exact requirement tag", %{project: project, user: user} do
+    version = insert_version("== 1.1.2", project, user)
+    insert_version("1.1.2", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, "== 1.1.2"))
+
+    assert_match_version(versions, version)
+  end
+
+  test "filter requirement tag with prefix", %{project: project, user: user} do
+    version = insert_version("v1.1.2", project, user)
+    insert_version("1.1.1", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, "== 1.1.2"))
+
+    assert_match_version(versions, version)
+  end
+
+  test "filter fish operator requirement tag", %{project: project, user: user} do
+    version = insert_version("1.1.2", project, user)
+    insert_version("1.1.0", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, "~> 1.0"))
+
+    assert_match_version(versions, version)
+  end
+
+  test "filter out invalid tag", %{project: project, user: user} do
+    version = insert_version("1.1.2", project, user)
+    insert_version("1.1.0", project, user)
+    insert_version("foo", project, user)
+    insert_version("bar", project, user)
+
+    versions = Repo.all(VersionScope.from_tag(Version, "~> 1.0"))
+
+    assert_match_version(versions, version)
+  end
 end


### PR DESCRIPTION
Fallback to using `Version.Requirement` when no exact match is found.

With this feature you can export a version tagged `v1.1.4` with `>= 1.0.0` or `~> 1.1`

🎉 

Closes #171 