### PR TITLE
Fix parsed document as nil for other formats

### DIFF
--- a/lib/hook/consumers/github/sync.ex
+++ b/lib/hook/consumers/github/sync.ex
@@ -51,14 +51,17 @@ defmodule Accent.Hook.Consumers.GitHub.Sync do
         entries: entries,
         assigns: %{
           document: document,
-          document_update: %{
-            top_of_the_file_comment: parsed_document && parsed_document.top_of_the_file_comment,
-            header: parsed_document && parsed_document.header
-          }
+          document_update: document_update(parsed_document)
         }
       }
     else
       _ -> nil
     end
+  end
+
+  defp document_update(nil), do: nil
+
+  defp document_update(parsed_document) do
+    %{top_of_the_file_comment: parsed_document.top_of_the_file_comment, header: parsed_document.header}
   end
 end

--- a/lib/hook/consumers/github/sync.ex
+++ b/lib/hook/consumers/github/sync.ex
@@ -52,8 +52,8 @@ defmodule Accent.Hook.Consumers.GitHub.Sync do
         assigns: %{
           document: document,
           document_update: %{
-            top_of_the_file_comment: parsed_document.top_of_the_file_comment,
-            header: parsed_document.header
+            top_of_the_file_comment: parsed_document && parsed_document.top_of_the_file_comment,
+            header: parsed_document && parsed_document.header
           }
         }
       }


### PR DESCRIPTION
`top_of_the_file_comment` and `header` are only used in Gettext format and the only real-world testing was with a Gettext file.

I will refactor this when the ARB format is merged with the unified `meta` field for document. It should be standard across formats.

Closes #177 