### PR TITLE
Add update comment UI and API on translation and projet comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.11.2
+          gleam-version: 0.13.2
 
       - name: Install System Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: 23.1.1
           elixir-version: 1.11.x

--- a/lib/accent/auth/role_abilities.ex
+++ b/lib/accent/auth/role_abilities.ex
@@ -15,6 +15,8 @@ defmodule Accent.RoleAbilities do
     index_translations
     index_comments
     create_comment
+    delete_comment
+    update_comment
     show_comment
     correct_all_revision
     uncorrect_all_revision

--- a/lib/accent/schemas/comment.ex
+++ b/lib/accent/schemas/comment.ex
@@ -29,6 +29,12 @@ defmodule Accent.Comment do
     end)
   end
 
+  def update_changeset(model, params) do
+    model
+    |> cast(params, ~w(text)a)
+    |> validate_required(~w(text)a)
+  end
+
   def delete_changeset(model) do
     model
     |> change()

--- a/lib/graphql/mutations/comment.ex
+++ b/lib/graphql/mutations/comment.ex
@@ -3,18 +3,27 @@ defmodule Accent.GraphQL.Mutations.Comment do
 
   import Accent.GraphQL.Helpers.Authorization
 
+  alias Accent.GraphQL.Resolvers.Comment, as: CommentResolver
+
   object :comment_mutations do
     field :create_comment, :mutated_comment do
       arg(:id, non_null(:id))
       arg(:text, non_null(:string))
 
-      resolve(translation_authorize(:create_comment, &Accent.GraphQL.Resolvers.Comment.create/3))
+      resolve(translation_authorize(:create_comment, &CommentResolver.create/3))
+    end
+
+    field :update_comment, :mutated_comment do
+      arg(:id, non_null(:id))
+      arg(:text, non_null(:string))
+
+      resolve(comment_authorize(:update_comment, &CommentResolver.update/3))
     end
 
     field :delete_comment, :mutated_comment do
       arg(:id, non_null(:id))
 
-      resolve(comment_authorize(:delete_comment, &Accent.GraphQL.Resolvers.Comment.delete/3))
+      resolve(comment_authorize(:delete_comment, &CommentResolver.delete/3))
     end
 
     field :create_translation_comments_subscription, :mutated_translation_comments_subscription do

--- a/lib/graphql/resolvers/comment.ex
+++ b/lib/graphql/resolvers/comment.ex
@@ -55,6 +55,20 @@ defmodule Accent.GraphQL.Resolvers.Comment do
     {:ok, %{comment: comment, errors: nil}}
   end
 
+  @spec update(Comment.t(), any(), GraphQLContext.t()) :: comment_operation
+  def update(comment, %{text: text}, _) do
+    comment
+    |> Comment.update_changeset(%{text: text})
+    |> Repo.update()
+    |> case do
+      {:ok, comment} ->
+        {:ok, %{comment: comment, errors: nil}}
+
+      {:error, _reason} ->
+        {:ok, %{comment: comment, errors: ["unprocessable_entity"]}}
+    end
+  end
+
   @spec list_project(Project.t(), %{page: number()}, GraphQLContext.t()) :: {:ok, Paginated.t(Comment.t())}
   def list_project(project, args, _) do
     Comment

--- a/test/graphql/resolvers/comment_test.exs
+++ b/test/graphql/resolvers/comment_test.exs
@@ -65,6 +65,17 @@ defmodule AccentTest.GraphQL.Resolvers.Comment do
     assert Repo.all(Comment) == []
   end
 
+  test "update", %{translation: translation, user: user} do
+    comment = %Comment{translation_id: translation.id, text: "test", user: user} |> Repo.insert!()
+
+    assert get_in(Repo.all(Comment), [Access.all(), Access.key(:id)]) == [comment.id]
+
+    {:ok, result} = Resolver.update(comment, %{text: "updated"}, nil)
+
+    assert get_in(result, [:errors]) == nil
+    assert get_in(Repo.all(Comment), [Access.all(), Access.key(:text)]) == ["updated"]
+  end
+
   test "list project", %{project: project, translation: translation, user: user} do
     comment = %Comment{translation_id: translation.id, text: "test", user: user} |> Repo.insert!()
 

--- a/webapp/app/pods/components/project-comments-list/component.ts
+++ b/webapp/app/pods/components/project-comments-list/component.ts
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 interface Args {
   project: any;
   comments: any;
+  onUpdateComment: (comment: {id: string; text: string}) => Promise<void>;
   onDeleteComment: (comment: {id: string}) => Promise<void>;
 }
 

--- a/webapp/app/pods/components/project-comments-list/item/component.ts
+++ b/webapp/app/pods/components/project-comments-list/item/component.ts
@@ -5,6 +5,7 @@ import parsedKeyProperty from 'accent-webapp/computed-macros/parsed-key';
 interface Args {
   groupedComment: any;
   project: any;
+  onUpdateComment: (comment: {id: string; text: string}) => Promise<void>;
   onDeleteComment: (comment: {id: string}) => Promise<void>;
 }
 

--- a/webapp/app/pods/components/project-comments-list/item/template.hbs
+++ b/webapp/app/pods/components/project-comments-list/item/template.hbs
@@ -39,5 +39,6 @@
       "translationCommentsList"
     }}
     @onDeleteComment={{@onDeleteComment}}
+    @onUpdateComment={{@onUpdateComment}}
   />
 </li>

--- a/webapp/app/pods/components/project-comments-list/template.hbs
+++ b/webapp/app/pods/components/project-comments-list/template.hbs
@@ -4,6 +4,7 @@
       @project={{@project}}
       @groupedComment={{groupedComment}}
       @onDeleteComment={{@onDeleteComment}}
+      @onUpdateComment={{@onUpdateComment}}
     />
   {{else}}
     <EmptyContent

--- a/webapp/app/pods/components/translation-comment-delete/template.hbs
+++ b/webapp/app/pods/components/translation-comment-delete/template.hbs
@@ -1,8 +1,7 @@
 <AsyncButton
   onClick={{fn this.deleteComment}}
-  class="button button--red button--small button--borderless"
   local-class="button"
   ...attributes
 >
-  {{t "components.translation_comment_delete.delete"}}
+  {{yield}}
 </AsyncButton>

--- a/webapp/app/pods/components/translation-comment-form/component.ts
+++ b/webapp/app/pods/components/translation-comment-form/component.ts
@@ -6,6 +6,7 @@ import {timeout} from 'ember-concurrency';
 import {MutationResponse} from 'accent-webapp/services/apollo-mutate';
 
 interface Args {
+  value?: string;
   onSubmit: (text: string) => Promise<MutationResponse>;
 }
 
@@ -13,7 +14,7 @@ const SUBMIT_DEBOUNCE = 1000;
 
 export default class TranslationCommentForm extends Component<Args> {
   @tracked
-  text = '';
+  text = this.args.value || '';
 
   @tracked
   error = false;

--- a/webapp/app/pods/components/translation-comment-form/styles.scss
+++ b/webapp/app/pods/components/translation-comment-form/styles.scss
@@ -1,7 +1,3 @@
-.translation-comment-form {
-  margin: 30px 0;
-}
-
 .form-content {
   display: flex;
   align-items: flex-start;

--- a/webapp/app/pods/components/translation-comment-form/template.hbs
+++ b/webapp/app/pods/components/translation-comment-form/template.hbs
@@ -16,7 +16,7 @@
         {{on "input" this.setText}}
         local-class="inputText"
         placeholder={{t "components.translation_comment_form.comment_placeholder"}}
-        rows="3"
+        rows="1"
         disabled={{this.submitTask.isRunning}}
         value={{this.text}}
       />

--- a/webapp/app/pods/components/translation-comments-list/component.ts
+++ b/webapp/app/pods/components/translation-comments-list/component.ts
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 interface Args {
   comments: any;
   onDeleteComment: (comment: {id: string}) => Promise<void>;
+  onUpdateComment: (comment: {id: string; text: string}) => Promise<void>;
 }
 
 export default class TranslationsCommentsList extends Component<Args> {}

--- a/webapp/app/pods/components/translation-comments-list/item/styles.scss
+++ b/webapp/app/pods/components/translation-comments-list/item/styles.scss
@@ -7,6 +7,7 @@
 .wrapper {
   &:focus,
   &:hover {
+    .button-edit,
     .button-delete {
       opacity: 1;
       transform: translate3d(0, 0, 0);
@@ -14,9 +15,23 @@
   }
 }
 
+:global(.button.button--small).button-edit {
+  padding: 0;
+  color: var(--color-grey);
+}
+
+:global(.button).button-edit,
 :global(.button).button-delete {
   opacity: 0;
   transform: translate3d(10px, 0, 0);
+
+  &:hover {
+    background: transparent;
+  }
+}
+
+.comment-form {
+  margin-top: 10px;
 }
 
 .user {
@@ -41,6 +56,14 @@
 }
 
 .content {
-  margin-top: 5px;
   font-size: 13px;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  p {
+    margin-top: 5px;
+  }
 }

--- a/webapp/app/pods/components/translation-comments-list/item/template.hbs
+++ b/webapp/app/pods/components/translation-comments-list/item/template.hbs
@@ -17,11 +17,47 @@
     </div>
 
     {{#if this.isAuthor }}
-      <TranslationCommentDelete local-class="button-delete" @onSubmit={{perform this.deleteComment}} />
+      <div>
+        <button
+          {{on "click" this.toggleEditComment}}
+          class="button button--small button--borderless"
+          local-class="button-edit"
+        >
+          {{#if this.editComment}}
+            {{inline-svg
+              "assets/x.svg"
+              class="button-icon"
+            }}
+          {{else}}
+            {{inline-svg
+              "assets/pencil.svg"
+              class="button-icon"
+            }}
+          {{/if}}
+        </button>
+
+        {{#unless this.editComment}}
+          <TranslationCommentDelete
+            class="button button--small button--red button--borderless"
+            local-class="button-delete" @onSubmit={{perform this.deleteComment}}
+          >
+            {{inline-svg
+              "assets/x.svg"
+              class="button-icon"
+            }}
+          </TranslationCommentDelete>
+        {{/unless}}
+      </div>
     {{/if}}
   </div>
 
-  <div local-class="content">
-    {{this.text}}
-  </div>
+  {{#if this.editComment}}
+    <div local-class="comment-form" {{did-insert this.focusTextarea}}>
+      <TranslationCommentForm @value={{@comment.text}} @onSubmit={{perform this.updateComment}} />
+    </div>
+  {{else}}
+    <div local-class="content">
+      {{this.text}}
+    </div>
+  {{/if}}
 </div>

--- a/webapp/app/pods/components/translation-comments-list/template.hbs
+++ b/webapp/app/pods/components/translation-comments-list/template.hbs
@@ -4,6 +4,7 @@
       <TranslationCommentsList::Item
         @comment={{comment}}
         @onDeleteComment={{@onDeleteComment}}
+        @onUpdateComment={{@onUpdateComment}}
       />
     </li>
   {{else}}

--- a/webapp/app/pods/components/translation-conversation/styles.scss
+++ b/webapp/app/pods/components/translation-conversation/styles.scss
@@ -7,6 +7,10 @@
   flex: 1 1 100%;
 }
 
+.comment-form {
+  margin: 32px 0;
+}
+
 .list {
   margin-top: 30px;
 }

--- a/webapp/app/pods/components/translation-conversation/template.hbs
+++ b/webapp/app/pods/components/translation-conversation/template.hbs
@@ -2,7 +2,7 @@
   <div local-class="comments">
     {{#if (get @permissions "create_comment")}}
       {{#unless @translation.isRemoved}}
-        <div {{did-insert this.focusTextarea}}>
+        <div local-class="comment-form" {{did-insert this.focusTextarea}}>
           <TranslationCommentForm @onSubmit={{@onSubmit}} />
         </div>
       {{/unless}}
@@ -11,6 +11,7 @@
     <div local-class="list">
       <TranslationCommentsList
         @comments={{@comments.entries}}
+        @onUpdateComment={{@onUpdateComment}}
         @onDeleteComment={{@onDeleteComment}}
         local-class="at-translation"
       />

--- a/webapp/app/pods/logged-in/project/comments/controller.ts
+++ b/webapp/app/pods/logged-in/project/comments/controller.ts
@@ -6,6 +6,7 @@ import {tracked} from '@glimmer/tracking';
 import IntlService from 'ember-intl/services/intl';
 
 import commentDeleteQuery from 'accent-webapp/queries/delete-comment';
+import commentUpdateQuery from 'accent-webapp/queries/update-comment';
 import ApolloMutate from 'accent-webapp/services/apollo-mutate';
 import FlashMessages from 'ember-cli-flash/services/flash-messages';
 
@@ -39,6 +40,18 @@ export default class CommentsController extends Controller {
     window.scroll(0, 0);
 
     this.page = page;
+  }
+
+  @action
+  async updateComment(comment: {id: string; text: string}) {
+    return this.apolloMutate.mutate({
+      mutation: commentUpdateQuery,
+      refetchQueries: ['ProjectComments'],
+      variables: {
+        commentId: comment.id,
+        text: comment.text,
+      },
+    });
   }
 
   @action

--- a/webapp/app/pods/logged-in/project/comments/template.hbs
+++ b/webapp/app/pods/logged-in/project/comments/template.hbs
@@ -8,6 +8,7 @@
   <ProjectCommentsList
     @project={{this.model.project}}
     @comments={{this.model.comments.entries}}
+    @onUpdateComment={{fn this.updateComment}}
     @onDeleteComment={{fn this.deleteComment}}
   />
   <ResourcePagination

--- a/webapp/app/pods/logged-in/project/translation/comments/controller.ts
+++ b/webapp/app/pods/logged-in/project/translation/comments/controller.ts
@@ -6,6 +6,7 @@ import IntlService from 'ember-intl/services/intl';
 
 import commentCreateQuery from 'accent-webapp/queries/create-comment';
 import commentDeleteQuery from 'accent-webapp/queries/delete-comment';
+import commentUpdateQuery from 'accent-webapp/queries/update-comment';
 import translationCommentsSubscriptionCreateQuery from 'accent-webapp/queries/create-translation-comments-subscription';
 import translationCommentsSubscriptionDeleteQuery from 'accent-webapp/queries/delete-translation-comments-subscription';
 import ApolloMutate from 'accent-webapp/services/apollo-mutate';
@@ -55,6 +56,18 @@ export default class CommentsController extends Controller {
       variables: {
         translationId: translation.id,
         text,
+      },
+    });
+  }
+
+  @action
+  async updateComment(comment: {id: string; text: string}) {
+    return this.apolloMutate.mutate({
+      mutation: commentUpdateQuery,
+      refetchQueries: ['TranslationComments'],
+      variables: {
+        commentId: comment.id,
+        text: comment.text,
       },
     });
   }

--- a/webapp/app/pods/logged-in/project/translation/comments/template.hbs
+++ b/webapp/app/pods/logged-in/project/translation/comments/template.hbs
@@ -14,6 +14,7 @@
     @onCreateSubscription={{fn this.createSubscription}}
     @onDeleteSubscription={{fn this.deleteSubscription}}
     @onSubmit={{fn this.createComment}}
+    @onUpdateComment={{fn this.updateComment}}
     @onDeleteComment={{fn this.deleteComment}}
     @onSelectPage={{fn this.selectPage}}
   />

--- a/webapp/app/queries/update-comment.ts
+++ b/webapp/app/queries/update-comment.ts
@@ -1,0 +1,14 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation CommentUpdate($commentId: ID!, $text: String!) {
+    updateComment(id: $commentId, text: $text) {
+      comment {
+        id
+        text
+      }
+
+      errors
+    }
+  }
+`;


### PR DESCRIPTION
A user can now edit its own comment either on the "translation’s conversation" page or the "projet’s conversation" page

## Translation
<img width="825" alt="image" src="https://user-images.githubusercontent.com/464900/107724921-f5474800-6cb2-11eb-9806-374da8823568.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/464900/107724928-fb3d2900-6cb2-11eb-877e-dde9772eb35b.png">

## Project
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/464900/107724979-1dcf4200-6cb3-11eb-83e6-fade2eedca57.png">

Fix #211 😄 