### PR TITLE
Add support for SSL database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Accent provides a default value for every required environment variable. This me
 | `WEBAPP_SENTRY_DSN`                       | _none_  | The _public_ Sentry DSN used to collect Webapp runtime errors                                                              |
 | `CANONICAL_URL`                           | _none_  | The URL of the app. Used in sent emails and to redirect from external services to the app in the authentication flow.      |
 | `WEBAPP_SKIP_SUBRESOURCE_INTEGRITY`       | _none_  | Remove integrity attributes on link and script tag. Useful when using a proxy that compress resources before serving them. |
+| `DATABASE_SSL`                            | _false_ | If SSL should be used to connect to the database                                                                           |
+| `DATABASE_POOL_SIZE`                      | _10_    | The size of the pool used by the database connection module                                                                |
 
 ### Authentication setup
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,7 @@ config :accent,
   ecto_repos: [Accent.Repo],
   version: version
 
-config :accent, Accent.Repo, timeout: 25_000
+config :accent, Accent.Repo, timeout: 25_000, start_apps_before_migration: [:ssl]
 
 config :accent, Accent.Endpoint,
   render_errors: [accepts: ~w(json)],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -40,7 +40,10 @@ else
     static_url: static_url
 end
 
-config :accent, Accent.Repo, url: System.get_env("DATABASE_URL") || "postgres://localhost/accent_development"
+config :accent, Accent.Repo,
+  pool_size: Environment.get_integer("DATABASE_POOL_SIZE"),
+  ssl: Environment.get_boolean("DATABASE_SSL"),
+  url: System.get_env("DATABASE_URL") || "postgres://localhost/accent_development"
 
 google_translate_provider = {Accent.MachineTranslations.Adapter.GoogleTranslations, [key: System.get_env("GOOGLE_TRANSLATIONS_SERVICE_ACCOUNT_KEY")]}
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,6 +4,9 @@ defmodule Utilities do
   def string_to_boolean("true"), do: true
   def string_to_boolean("1"), do: true
   def string_to_boolean(_), do: false
+
+  def string_to_integer(value) when is_bitstring(value), do: String.to_integer(value)
+  def string_to_integer(_), do: nil
 end
 
 canonical_url = System.get_env("CANONICAL_URL") || "http://localhost:4000"
@@ -41,8 +44,8 @@ else
 end
 
 config :accent, Accent.Repo,
-  pool_size: Environment.get_integer("DATABASE_POOL_SIZE"),
-  ssl: Environment.get_boolean("DATABASE_SSL"),
+  pool_size: Utilities.string_to_integer(System.get_env("DATABASE_POOL_SIZE")),
+  ssl: Utilities.string_to_boolean(System.get_env("DATABASE_SSL")),
   url: System.get_env("DATABASE_URL") || "postgres://localhost/accent_development"
 
 google_translate_provider = {Accent.MachineTranslations.Adapter.GoogleTranslations, [key: System.get_env("GOOGLE_TRANSLATIONS_SERVICE_ACCOUNT_KEY")]}


### PR DESCRIPTION
_Taken straight from [elixir-boilerplate](https://github.com/mirego/elixir-boilerplate/) 🤓_ 

---

This pull request adds support for both `DATABASE_SSL` and `DATABASE_POOL_SIZE` environment variables. These variables are passed down to the Ecto repo configuration.

This should fix #240.