### PR TITLE
Ecto - support IPv6 connections

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,10 +43,13 @@ else
     static_url: static_url
 end
 
+ecto_ipv6? = System.get_env("ECTO_IPV6") == "true"
+
 config :accent, Accent.Repo,
   pool_size: Utilities.string_to_integer(System.get_env("DATABASE_POOL_SIZE")),
   ssl: Utilities.string_to_boolean(System.get_env("DATABASE_SSL")),
-  url: System.get_env("DATABASE_URL") || "postgres://localhost/accent_development"
+  url: System.get_env("DATABASE_URL") || "postgres://localhost/accent_development",
+  socket_options: if(ecto_ipv6?, do: [:inet6], else: [])
 
 google_translate_provider = {Accent.MachineTranslations.Adapter.GoogleTranslations, [key: System.get_env("GOOGLE_TRANSLATIONS_SERVICE_ACCOUNT_KEY")]}
 


### PR DESCRIPTION
Based on advice from Chris McCord on [Fly.io's forum](https://community.fly.io/t/nxdomain-for-elixir-app/6704) I would like to add this code change. It's not possible to deploy this application on fly.io without this configuration. I tried and it works. 