### PR TITLE
Cleanup Unicode context for iOS .strings

### DIFF
--- a/lib/langue/formatter/strings/parser.ex
+++ b/lib/langue/formatter/strings/parser.ex
@@ -8,7 +8,7 @@ defmodule Langue.Formatter.Strings.Parser do
   def parse(%{render: render}) do
     entries =
       render
-      |> LineByLineHelper.Parser.lines(@prop_line_regex, ";\n")
+      |> LineByLineHelper.Parser.lines(@prop_line_regex, ";")
       |> Placeholders.parse(Langue.Formatter.Strings.placeholder_regex())
 
     %Langue.Formatter.ParserResult{entries: entries}

--- a/lib/utils/clean_context.ex
+++ b/lib/utils/clean_context.ex
@@ -1,0 +1,43 @@
+defmodule Accent.CleanContext do
+  @specials [
+    <<255, 240>>,
+    <<255, 241>>,
+    <<255, 242>>,
+    <<255, 243>>,
+    <<255, 244>>,
+    <<255, 245>>,
+    <<255, 246>>,
+    <<255, 247>>,
+    <<255, 248>>,
+    <<255, 240>>,
+    <<255, 16>>,
+    <<255, 17>>,
+    <<255, 18>>,
+    <<255, 19>>,
+    <<255, 20>>,
+    <<255, 250>>,
+    <<255, 251>>,
+    <<255, 252>>,
+    <<255, 254>>,
+    <<255, 255>>
+  ]
+
+  @replacement_character "�"
+
+  def unicode_only(string, new_string \\ "")
+
+  def unicode_only(<<head::binary-size(2)>> <> tail, new_string)
+      when head in @specials do
+    unicode_only(tail, @replacement_character <> new_string)
+  end
+
+  def unicode_only(<<head::binary-size(1)>> <> tail, new_string) do
+    if String.printable?(head) do
+      unicode_only(tail, head <> new_string)
+    else
+      unicode_only(tail, new_string)
+    end
+  end
+
+  def unicode_only("", new_string), do: String.reverse(new_string)
+end

--- a/lib/utils/clean_context.ex
+++ b/lib/utils/clean_context.ex
@@ -32,10 +32,15 @@ defmodule Accent.CleanContext do
   end
 
   def unicode_only(<<head::binary-size(1)>> <> tail, new_string) do
-    if String.printable?(head) do
-      unicode_only(tail, head <> new_string)
-    else
-      unicode_only(tail, new_string)
+    printable_head? = String.printable?(head)
+    printable_tail? = String.printable?(tail)
+    cond do
+      printable_head? and printable_tail? ->
+        String.reverse(new_string) <> head <> tail
+      printable_head? ->
+        unicode_only(tail, head <> new_string)
+      true ->
+        unicode_only(tail, new_string)
     end
   end
 

--- a/lib/web/plugs/movement_context_parser.ex
+++ b/lib/web/plugs/movement_context_parser.ex
@@ -1,7 +1,7 @@
 defmodule Accent.Plugs.MovementContextParser do
   use Plug.Builder
 
-  alias Accent.{Document, Repo, Version}
+  alias Accent.{Document, Repo, Version, CleanContext}
   alias Accent.Scopes.Document, as: DocumentScope
   alias Accent.Scopes.Version, as: VersionScope
   alias Movement.Context
@@ -85,7 +85,12 @@ defmodule Accent.Plugs.MovementContextParser do
   end
 
   def assign_movement_entries(conn = %{assigns: %{movement_context: context}, params: %{"file" => file}}, _) do
-    render = File.read!(file.path)
+    raw = File.read!(file.path)
+    render = String.printable?(raw)
+      |> case do
+        true -> raw
+        false -> CleanContext.unicode_only(raw)
+      end
 
     conn
     |> parser_result(render)

--- a/lib/web/plugs/movement_context_parser.ex
+++ b/lib/web/plugs/movement_context_parser.ex
@@ -86,11 +86,7 @@ defmodule Accent.Plugs.MovementContextParser do
 
   def assign_movement_entries(conn = %{assigns: %{movement_context: context}, params: %{"file" => file}}, _) do
     raw = File.read!(file.path)
-    render = String.printable?(raw)
-      |> case do
-        true -> raw
-        false -> CleanContext.unicode_only(raw)
-      end
+    render = CleanContext.unicode_only(raw)
 
     conn
     |> parser_result(render)


### PR DESCRIPTION
Issue: https://github.com/mirego/accent/issues/340

it's related to the file encoding!

the attached file contained non-unicode or un-printable letters. so failed while reading <> parsing the file. 
so i added the utility module to convert binary to string by removing those wrong bytes. 

