### PR TITLE
Cache dependencies during CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
           node-version-file: .tool-versions
           cache: npm
           cache-dependency-path: |
-            - package-lock.json
-            - cli/package-lock.json
-            - jipt/package-lock.json
-            - webapp/package-lock.json
+            package-lock.json
+            cli/package-lock.json
+            jipt/package-lock.json
+            webapp/package-lock.json
 
       - name: Install System Dependencies
         run: |


### PR DESCRIPTION
Also use `.tool-versions` as a source of truth for versions instead of duplicating the information.