### PR TITLE
Add DATABASE_SSL env var to app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ $> heroku addons:create heroku-postgresql:hobby-dev --app peaceful-badlands-8588
 Creating heroku-postgresql:hobby-dev on ⬢ peaceful-badlands-85887... free
 Database has been created and is available
 
-$> heroku config:set FORCE_SSL=true DUMMY_LOGIN_ENABLED=true --app peaceful-badlands-85887
-Setting FORCE_SSL, DUMMY_LOGIN_ENABLED and restarting ⬢ peaceful-badlands-85887... done
+$> heroku config:set FORCE_SSL=true DATABASE_SSL=true DUMMY_LOGIN_ENABLED=true --app peaceful-badlands-85887
+Setting FORCE_SSL, DATABASE_SSL, DUMMY_LOGIN_ENABLED and restarting ⬢ peaceful-badlands-85887... done
 
 $> heroku container:push web --app peaceful-badlands-85887
 === Building web

--- a/app.json
+++ b/app.json
@@ -27,6 +27,11 @@
       "description": "The default login to quickly test the instance. It only requires the user to enter a valid email to login.",
       "value": "true",
       "required": false
+    },
+    "DATABASE_SSL": {
+      "description": "Indicates that SSL is required for the database connection.",
+      "value": "true",
+      "required": false
     }
   },
   "addons": [


### PR DESCRIPTION
Heroku Postgres now requires SSL connections. Considering that the addition of the `?sslmode=require` parameter to `DATABASE_URL` is no longer possible, setting `DATABASE_SSL=true` serves as a sensible default.

Sloves https://github.com/mirego/accent/issues/310