### PR TITLE
Add output and error handling to hook-runner

### DIFF
--- a/cli/src/services/formatters/hook-runner.ts
+++ b/cli/src/services/formatters/hook-runner.ts
@@ -21,4 +21,9 @@ export default class HookRunnerFomatter {
     });
     console.log('');
   }
+  success(command: string, message: string) {
+    console.log(chalk.green('✓ '), chalk.bold(chalk.green(`${command}:`)));
+    console.log('  ', chalk.green(message));
+    console.log('');
+}
 }

--- a/cli/src/services/formatters/hook-runner.ts
+++ b/cli/src/services/formatters/hook-runner.ts
@@ -7,7 +7,7 @@ const capitalizeFirstLetter = (str: string) =>
 
 export default class HookRunnerFomatter {
   log(name: string, commands: string[]) {
-    const operation = capitalizeFirstLetter(decamelize(name, {separator: ' '}));
+    const operation = capitalizeFirstLetter(decamelize(name, { separator: ' ' }));
     console.log(chalk.yellow('➤ '), chalk.bold(chalk.yellow(`${operation}:`)));
     commands.forEach((command) => {
       console.log('  ', chalk.yellow(command));

--- a/cli/src/services/formatters/hook-runner.ts
+++ b/cli/src/services/formatters/hook-runner.ts
@@ -7,7 +7,7 @@ const capitalizeFirstLetter = (str: string) =>
 
 export default class HookRunnerFomatter {
   log(name: string, commands: string[]) {
-    const operation = capitalizeFirstLetter(decamelize(name, { separator: ' ' }));
+    const operation = capitalizeFirstLetter(decamelize(name, {separator: ' '}));
     console.log(chalk.yellow('➤ '), chalk.bold(chalk.yellow(`${operation}:`)));
     commands.forEach((command) => {
       console.log('  ', chalk.yellow(command));

--- a/cli/src/services/formatters/hook-runner.ts
+++ b/cli/src/services/formatters/hook-runner.ts
@@ -14,4 +14,11 @@ export default class HookRunnerFomatter {
     });
     console.log('');
   }
+  error(command: string, errors: string[]) {
+    console.log(chalk.red('⚠ '), chalk.bold(chalk.red(`${command}:`)));
+    errors.forEach((error) => {
+      console.log('  ', chalk.red(error));
+    });
+    console.log('');
+  }
 }

--- a/cli/src/services/hook-runner.ts
+++ b/cli/src/services/hook-runner.ts
@@ -1,11 +1,11 @@
 // Vendor
-import { execSync } from 'child_process';
+import {execSync} from 'child_process';
 
 // Formatters
 import Formatter from './formatters/hook-runner';
 
 // Types
-import { HookConfig, Hooks } from '../types/document-config';
+import {HookConfig, Hooks} from '../types/document-config';
 import Document from './document';
 
 export default class HookRunner {
@@ -23,13 +23,13 @@ export default class HookRunner {
     const hooks = this.hooks[name];
 
     if (hooks) {
-      const formatter = new Formatter()
+      const formatter = new Formatter();
       formatter.log(name, hooks);
 
       hooks.forEach((hook) => {
         try {
-          const output: string = execSync(hook, { stdio: 'pipe' }).toString();
-          formatter.log(hook, [output])
+          const output: string = execSync(hook, {stdio: 'pipe'}).toString();
+          formatter.log(hook, [output]);
         } catch (error: any) {
           formatter.error(hook, [error.stderr.toString()]);
           process.exit(error.status);

--- a/cli/src/services/hook-runner.ts
+++ b/cli/src/services/hook-runner.ts
@@ -23,9 +23,18 @@ export default class HookRunner {
     const hooks = this.hooks[name];
 
     if (hooks) {
-      new Formatter().log(name, hooks);
+      const formatter = new Formatter()
+      formatter.log(name, hooks);
 
-      hooks.forEach(execSync);
+      hooks.forEach((hook) => {
+        try {
+          const output: string = execSync(hook, { stdio: 'pipe' }).toString();
+          formatter.log(hook, [output])
+        } catch (error: any) {
+          formatter.error(hook, [error.stderr.toString()]);
+          throw new Error(`Hook execution failed for '${hook}': ${error.stderr.toString()}`);
+        }
+      });
     }
 
     return this.document.refreshPaths();

--- a/cli/src/services/hook-runner.ts
+++ b/cli/src/services/hook-runner.ts
@@ -1,11 +1,11 @@
 // Vendor
-import {execSync} from 'child_process';
+import { execSync } from 'child_process';
 
 // Formatters
 import Formatter from './formatters/hook-runner';
 
 // Types
-import {HookConfig, Hooks} from '../types/document-config';
+import { HookConfig, Hooks } from '../types/document-config';
 import Document from './document';
 
 export default class HookRunner {
@@ -32,7 +32,7 @@ export default class HookRunner {
           formatter.log(hook, [output])
         } catch (error: any) {
           formatter.error(hook, [error.stderr.toString()]);
-          throw new Error(`Hook execution failed for '${hook}': ${error.stderr.toString()}`);
+          process.exit(error.status);
         }
       });
     }

--- a/cli/src/services/hook-runner.ts
+++ b/cli/src/services/hook-runner.ts
@@ -29,7 +29,7 @@ export default class HookRunner {
       hooks.forEach((hook) => {
         try {
           const output: string = execSync(hook, {stdio: 'pipe'}).toString();
-          formatter.log(hook, [output]);
+          formatter.success(hook, output);
         } catch (error: any) {
           formatter.error(hook, [error.stderr.toString()]);
           process.exit(error.status);


### PR DESCRIPTION
In the process of adding a beforeSync hook that runs a bash script, i realized that echo in the script was not working. 

So I modified hook-runner and it's formatter to be able to output both the stdout and the stderror of a script