### PR TITLE
formatter.error accepts an array of strings

### DIFF
--- a/cli/src/services/hook-runner.ts
+++ b/cli/src/services/hook-runner.ts
@@ -34,7 +34,7 @@ export default class HookRunner {
           const output = error.stderr.toString();
 
           if (output.length > 0) {
-            formatter.error(hook, output);
+            formatter.error(hook, [output]);
           } else {
             formatter.error(hook, [`Exit status: ${error.status}`]);
           }


### PR DESCRIPTION
Quick fix following a refactor that missed enclosing the error output in an array