### PR TITLE
fix: don't reference schema explicitly

### DIFF
--- a/priv/repo/migrations/20221109201623_alter_operations_translation_id_constraint.exs
+++ b/priv/repo/migrations/20221109201623_alter_operations_translation_id_constraint.exs
@@ -10,7 +10,7 @@ defmodule Accent.Repo.Migrations.AlterOperationsTranslationIdConstraint do
 
     execute("""
     ALTER TABLE operations
-    ADD CONSTRAINT "operations_translation_id_fkey" FOREIGN KEY ("translation_id") REFERENCES "public"."translations"("id") DEFERRABLE INITIALLY DEFERRED
+    ADD CONSTRAINT "operations_translation_id_fkey" FOREIGN KEY ("translation_id") REFERENCES "translations"("id") DEFERRABLE INITIALLY DEFERRED
     """)
   end
 
@@ -22,7 +22,7 @@ defmodule Accent.Repo.Migrations.AlterOperationsTranslationIdConstraint do
 
     execute("""
     ALTER TABLE operations
-    ADD CONSTRAINT "operations_translation_id_fkey" FOREIGN KEY ("translation_id") REFERENCES "public"."translations"("id")
+    ADD CONSTRAINT "operations_translation_id_fkey" FOREIGN KEY ("translation_id") REFERENCES "translations"("id")
     """)
   end
 end


### PR DESCRIPTION
The `public` schema should not be referenced directly to support the usage of other Postgres schemas.