### PR TITLE
Heroku app.json: Use Postgres 16

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,7 +38,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "13"
+        "version": "16"
       }
     }
  ]


### PR DESCRIPTION
Since Postgres 13 is deprecated.

Should close https://github.com/mirego/accent/issues/442