### PR TITLE
feat: Add DeepL Pro

### DIFF
--- a/lib/machine_translations/provider/deepl.ex
+++ b/lib/machine_translations/provider/deepl.ex
@@ -72,10 +72,16 @@ defmodule Accent.MachineTranslations.Provider.Deepl do
     end
 
     defp client(key) do
+      base_url = if String.ends_with?(key, ":fx") do
+        "https://api-free.deepl.com/v2/"
+      else
+        "https://api.deepl.com/v2/"
+      end
+
       middlewares =
         List.flatten([
           {Middleware.Timeout, [timeout: :infinity]},
-          {Middleware.BaseUrl, "https://api-free.deepl.com/v2/"},
+          {Middleware.BaseUrl, base_url},
           {Auth, [key: key]},
           Middleware.DecodeJson,
           Middleware.EncodeJson,


### PR DESCRIPTION
Hello,

I update the DeepL machine translation provider to use version free or pro version based on API Key.
According to the [DeepL API Documentation](https://developers.deepl.com/docs/getting-started/auth):

> DeepL API Free authentication keys can be identified easily by the suffix ":fx" (e.g., 279a2e9d-83b3-c416-7e2d-f721593e42a0:fx)

Could you please review and accept the merge?
Thanks in advance.

Best regards,

Fabien