### PR TITLE
Adds ability to disable TzData's autoupdate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Accent provides a default value for every required environment variable. This me
 ### Production setup
 
 | Variable                                  | Default                    | Description                                                                                                                |
-| ----------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------|----------------------------|----------------------------------------------------------------------------------------------------------------------------|
 | `RESTRICTED_PROJECT_CREATOR_EMAIL_DOMAIN` | _none_                     | If specified, only authenticated users from this domain name will be able to create new projects.                          |
 | `FORCE_SSL`                               | _false_                    | If the app should always be served by https (and wss for websocket)                                                        |
 | `SENTRY_DSN`                              | _none_                     | The _secret_ Sentry DSN used to collect API runtime errors                                                                 |
@@ -135,6 +135,7 @@ Accent provides a default value for every required environment variable. This me
 | `DATABASE_SSL`                            | _false_                    | If SSL should be used to connect to the database                                                                           |
 | `DATABASE_POOL_SIZE`                      | _10_                       | The size of the pool used by the database connection module                                                                |
 | `MACHINE_TRANSLATIONS_VAULT_KEY`          | _DEFAULT_UNSAFE_VAULT_KEY_ | The secret key that is used to encrypt machine translations services config key                                            |
+| `TZDATA_AUTOUPDATE_DISABLED`              | _none_                     | Turn off automatic updates for Tzdata, needed when running read-only containers                                            |
 
 ### Authentication setup
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -216,6 +216,9 @@ cond do
       username: get_env("SMTP_USERNAME"),
       password: get_env("SMTP_PASSWORD")
 
+  get_env("TZDATA_AUTOUPDATE_DISABLED") ->
+    config :tzdata, :autoupdate, :disabled
+
   config_env() == :test ->
     config :accent, Accent.Mailer,
       mailer_from: "accent-test@example.com",


### PR DESCRIPTION
When running accent in a read-only container the app fails to start because it fails with the following error

```
** (File.Error) could not write to file "/opt/accent/lib/tzdata-1.1.2/priv/latest_remote_poll.txt": read-only file system
```

This change allows the user to set `TZDATA_AUTOUPDATE_DISABLED=true` to disable Tzdata's auto update feature. 