### PR TITLE
Add example char to lint errors

### DIFF
--- a/cli/src/services/formatters/project-lint.ts
+++ b/cli/src/services/formatters/project-lint.ts
@@ -93,11 +93,11 @@ export default class ProjectLintFormatter extends Base {
       case 'double_spaces':
         return 'String contains double spaces';
       case 'apostrophe_as_single_quote':
-        return 'A single quote as been used instead of an apostrophe';
+        return "A single quote (') as been used instead of an apostrophe (’)";
       case 'first_letter_case':
         return 'First letter of translation does not match case of the master’s';
       case 'three_dots_ellipsis':
-        return 'String contains three dots instead of ellipsis';
+        return 'String contains three dots (...) instead of ellipsis (…)';
       case 'same_trailing_character':
         return 'String does not match the trailing character of master';
       case 'url_count':


### PR DESCRIPTION
When an AI agent is linting my project, it has a hard time figuring out how to fix those issues. I think providing the actual characters in the linting error would help a lot.