### PR TITLE
Enable cross-compilation using QEMU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN mkdir -p /build/priv/native/ && \
 ################################################################################
 FROM hexpm/elixir:1.18.3-erlang-27.3.1-debian-bullseye-20250317-slim AS builder
 
+ENV ERL_AFLAGS="+JMsingle true"
 ENV MIX_ENV=prod
 WORKDIR /build
 


### PR DESCRIPTION
The [JMSingle flag](https://www.erlang.org/doc/apps/erts/erl_cmd.html#%2BJMsingle) is needed to disable dual mapping, which doesn't work with QEMU user mode emulation.

This should unblock #377.