### PR TITLE
Fix XLIFF 1.2 parser for Symfony compatibility and standards compliance

### DIFF
--- a/test/langue/xliff_1_2/expectation_test.exs
+++ b/test/langue/xliff_1_2/expectation_test.exs
@@ -1,10 +1,11 @@
 defmodule LangueTest.Formatter.XLIFF12.Expectation do
   @moduledoc false
   alias Langue.Entry
+  alias Langue.Expectation.Case
 
   defmodule Simple do
     @moduledoc false
-    use Langue.Expectation.Case
+    use Case
 
     def render do
       """
@@ -32,6 +33,113 @@ defmodule LangueTest.Formatter.XLIFF12.Expectation do
         %Entry{key: "greeting", value: "bonjour", master_value: "hello", index: 1, value_type: "string"},
         %Entry{key: "goodbye", value: "À la prochaine", master_value: "Bye bye", index: 2, value_type: "string"},
         %Entry{key: "empty", value: "", master_value: "", index: 3, value_type: "empty"}
+      ]
+    end
+  end
+
+  defmodule SymfonyFormat do
+    @moduledoc false
+    use Case
+
+    def render do
+      """
+      <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+        <file original="project-a" datatype="plaintext" source-language="en" target-language="fr">
+          <body>
+            <trans-unit id="greeting">
+              <source>hello</source>
+              <target>bonjour</target>
+            </trans-unit>
+            <trans-unit id="goodbye">
+              <source>Bye bye</source>
+              <target>À la prochaine</target>
+            </trans-unit>
+          </body>
+        </file>
+      </xliff>
+      """
+    end
+
+    def entries do
+      [
+        %Entry{key: "greeting", value: "bonjour", master_value: "hello", index: 1, value_type: "string"},
+        %Entry{key: "goodbye", value: "À la prochaine", master_value: "Bye bye", index: 2, value_type: "string"}
+      ]
+    end
+  end
+
+  defmodule HeaderAndBody do
+    @moduledoc false
+    use Case
+
+    def render do
+      """
+      <file original="project-a" datatype="plaintext" source-language="en" target-language="fr">
+        <header>
+          <tool tool-id="symfony" tool-name="Symfony"/>
+        </header>
+        <body>
+          <trans-unit id="greeting">
+            <source>hello</source>
+            <target>bonjour</target>
+          </trans-unit>
+        </body>
+      </file>
+      """
+    end
+
+    def entries do
+      [
+        %Entry{key: "greeting", value: "bonjour", master_value: "hello", index: 1, value_type: "string"}
+      ]
+    end
+  end
+
+  defmodule TransUnitWithNotes do
+    @moduledoc false
+    use Case
+
+    def render do
+      """
+      <file original="project-a" datatype="plaintext" source-language="en" target-language="fr">
+        <body>
+          <trans-unit id="greeting" xml:space="preserve">
+            <source>hello</source>
+            <target>bonjour</target>
+            <note>Greeting message</note>
+          </trans-unit>
+        </body>
+      </file>
+      """
+    end
+
+    def entries do
+      [
+        %Entry{key: "greeting", value: "bonjour", master_value: "hello", index: 1, value_type: "string"}
+      ]
+    end
+  end
+
+  defmodule ReorderedSourceTarget do
+    @moduledoc false
+    use Case
+
+    def render do
+      """
+      <file original="project-a" datatype="plaintext" source-language="en" target-language="fr">
+        <body>
+          <trans-unit id="greeting">
+            <target>bonjour</target>
+            <source>hello</source>
+          </trans-unit>
+        </body>
+      </file>
+      """
+    end
+
+    def entries do
+      [
+        %Entry{key: "greeting", value: "bonjour", master_value: "hello", index: 1, value_type: "string"}
       ]
     end
   end

--- a/test/langue/xliff_1_2/parse_only_test.exs
+++ b/test/langue/xliff_1_2/parse_only_test.exs
@@ -1,0 +1,27 @@
+defmodule LangueTest.Formatter.XLIFF12.ParseOnly do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Langue.Formatter.XLIFF12
+  alias LangueTest.Formatter.XLIFF12.Expectation.HeaderAndBody
+  alias LangueTest.Formatter.XLIFF12.Expectation.ReorderedSourceTarget
+  alias LangueTest.Formatter.XLIFF12.Expectation.SymfonyFormat
+  alias LangueTest.Formatter.XLIFF12.Expectation.TransUnitWithNotes
+
+  Code.require_file("expectation_test.exs", __DIR__)
+
+  @tests [
+    SymfonyFormat,
+    HeaderAndBody,
+    TransUnitWithNotes,
+    ReorderedSourceTarget
+  ]
+
+  for test <- @tests do
+    test "xliff 1.2 parse #{test}" do
+      {expected_parse, result_parse} = Accent.FormatterTestHelper.test_parse(unquote(test), XLIFF12)
+
+      assert expected_parse == result_parse
+    end
+  end
+end


### PR DESCRIPTION
**_DRAFT PULL REQUEST ONLY_**

---

Issue #494

Fix XLIFF 1.2 parser for standards compliance (#494)

Replace rigid pattern matching with flexible element-finding functions so the parser handles standard-compliant XLIFF files from tools like Symfony: `<xliff>` root wrappers, `<header>` elements, extra attributes and children in `<trans-unit>`, and reordered `<source>`/`<target>`.

---

Note: the diff is mostly the result of Claude Code (Opus 4.6).

I didn't made enough checks myself to send this pull request with a status different than draft.
I don't have knowledge of this product, I am not used to this tech stack so take this with appropriate precautions.